### PR TITLE
Add APICommon and Token tests.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -274,6 +274,7 @@
         <test name="us.kbase.test.groups.core.request.RequestIDTest"/>
         <test name="us.kbase.test.groups.integration.ServiceIntegrationTest"/>
         <test name="us.kbase.test.groups.service.LoggingFilterTest"/>
+        <test name="us.kbase.test.groups.service.api.APICommonTest"/>
         <test name="us.kbase.test.groups.service.api.GroupsAPITest"/>
         <test name="us.kbase.test.groups.service.api.RequestAPITest"/>
         <test name="us.kbase.test.groups.service.api.RootTest"/>

--- a/build.xml
+++ b/build.xml
@@ -267,6 +267,7 @@
         <test name="us.kbase.test.groups.core.GroupCreationParamsTest"/>
         <test name="us.kbase.test.groups.core.GroupTypeTest"/>
         <test name="us.kbase.test.groups.core.NameTest"/>
+        <test name="us.kbase.test.groups.core.TokenTest"/>
         <test name="us.kbase.test.groups.core.request.GroupRequestTest"/>
         <test name="us.kbase.test.groups.core.request.GroupRequestStatusTypeTest"/>
         <test name="us.kbase.test.groups.core.request.GroupRequestTypeTest"/>

--- a/src/us/kbase/groups/core/Token.java
+++ b/src/us/kbase/groups/core/Token.java
@@ -5,20 +5,21 @@ import static us.kbase.groups.util.Util.checkString;
 import us.kbase.groups.core.exceptions.MissingParameterException;
 
 
+/** An authentication token used to identify a user.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class Token {
-	
-	// TODO JAVADOC
-	// TODO TEST
 	
 	private final String token;
 
 	/** Create a token.
 	 * @param token the token string
-	 * @throws MissingParameterException if the token string is null or empty.
+	 * @throws MissingParameterException if the token string is null or whitespace only.
 	 */
 	public Token(final String token) throws MissingParameterException {
 		checkString(token, "token");
-		this.token = token.trim();
+		this.token = token;
 	}
 
 	/** Get the token string.

--- a/src/us/kbase/groups/service/api/APICommon.java
+++ b/src/us/kbase/groups/service/api/APICommon.java
@@ -16,8 +16,6 @@ import us.kbase.groups.core.request.GroupRequest;
 
 public class APICommon {
 	
-	// TODO TEST
-
 	/** Transform a {@link GroupRequest} object into a Map/List structure suitable for
 	 * serializing to JSON.
 	 * @param request the request object.

--- a/src/us/kbase/test/groups/core/TokenTest.java
+++ b/src/us/kbase/test/groups/core/TokenTest.java
@@ -1,0 +1,43 @@
+package us.kbase.test.groups.core;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.groups.core.Token;
+import us.kbase.groups.core.exceptions.MissingParameterException;
+import us.kbase.test.groups.TestCommon;
+
+public class TokenTest {
+	
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(Token.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void construct() throws Exception {
+		final Token t = new Token(" im a token  ");
+		
+		assertThat("incorrect token", t.getToken(), is(" im a token  "));
+	}
+	
+	@Test
+	public void constructFail() throws Exception {
+		failConstruct(null, new MissingParameterException("token"));
+		failConstruct("    \t     ", new MissingParameterException("token"));
+	}
+	
+	private void failConstruct(final String token, final Exception expected) {
+		try {
+			new Token(token);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+
+}

--- a/src/us/kbase/test/groups/service/api/APICommonTest.java
+++ b/src/us/kbase/test/groups/service/api/APICommonTest.java
@@ -1,0 +1,175 @@
+package us.kbase.test.groups.service.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import us.kbase.groups.core.CreateModAndExpireTimes;
+import us.kbase.groups.core.GroupID;
+import us.kbase.groups.core.Token;
+import us.kbase.groups.core.UserName;
+import us.kbase.groups.core.exceptions.NoTokenProvidedException;
+import us.kbase.groups.core.request.GroupRequest;
+import us.kbase.groups.core.request.GroupRequestStatus;
+import us.kbase.groups.core.request.RequestID;
+import us.kbase.groups.service.api.APICommon;
+import us.kbase.test.groups.MapBuilder;
+import us.kbase.test.groups.TestCommon;
+
+public class APICommonTest {
+	
+	@Test
+	public void toGroupRequestJSON() throws Exception {
+		final UUID id = UUID.randomUUID();
+		final GroupRequest r = GroupRequest.getBuilder(
+				new RequestID(id), new GroupID("gid"), new UserName("n"),
+				CreateModAndExpireTimes.getBuilder(
+						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
+						.build())
+				.withRequestGroupMembership()
+				.build();
+		
+		assertThat("incorrect request", APICommon.toGroupRequestJSON(r), is(MapBuilder.newHashMap()
+				.with("id", id.toString())
+				.with("groupid", "gid")
+				.with("requester", "n")
+				.with("targetuser", null)
+				.with("type", "Request group membership")
+				.with("status", "Open")
+				.with("createdate", 10000L)
+				.with("moddate", 10000L)
+				.with("expiredate", 20000L)
+				.build()));
+	}
+	
+	@Test
+	public void toGroupRequestJSONWithTarget() throws Exception {
+		final UUID id = UUID.randomUUID();
+		final GroupRequest r = GroupRequest.getBuilder(
+				new RequestID(id), new GroupID("gid"), new UserName("n"),
+				CreateModAndExpireTimes.getBuilder(
+						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
+						.withModificationTime(Instant.ofEpochMilli(25000))
+						.build())
+				.withInviteToGroup(new UserName("inv"))
+				.withStatus(GroupRequestStatus.denied(new UserName("den"), "r"))
+				.build();
+		
+		assertThat("incorrect request", APICommon.toGroupRequestJSON(r), is(MapBuilder.newHashMap()
+				.with("id", id.toString())
+				.with("groupid", "gid")
+				.with("requester", "n")
+				.with("targetuser", "inv")
+				.with("type", "Invite to group")
+				.with("status", "Denied")
+				.with("createdate", 10000L)
+				.with("moddate", 25000L)
+				.with("expiredate", 20000L)
+				.build()));
+	}
+	
+	@Test
+	public void toGroupRequestJSONFail() throws Exception {
+		try {
+			APICommon.toGroupRequestJSON((GroupRequest) null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("request"));
+		}
+	}
+	
+	@Test
+	public void toGroupRequestJSONList() throws Exception {
+		final UUID id1 = UUID.randomUUID();
+		final GroupRequest r1 = GroupRequest.getBuilder(
+				new RequestID(id1), new GroupID("gid1"), new UserName("n1"),
+				CreateModAndExpireTimes.getBuilder(
+						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
+						.build())
+				.withRequestGroupMembership()
+				.build();
+		
+		final UUID id2 = UUID.randomUUID();
+		final GroupRequest r2 = GroupRequest.getBuilder(
+				new RequestID(id2), new GroupID("gid2"), new UserName("n2"),
+				CreateModAndExpireTimes.getBuilder(
+						Instant.ofEpochMilli(11000), Instant.ofEpochMilli(21000))
+						.withModificationTime(Instant.ofEpochMilli(26000))
+						.build())
+				.withInviteToGroup(new UserName("inv"))
+				.withStatus(GroupRequestStatus.denied(new UserName("den"), "r"))
+				.build();
+		
+		assertThat("incorrect request", APICommon.toGroupRequestJSON(Arrays.asList(r2, r1)),
+				is(Arrays.asList(
+						MapBuilder.newHashMap()
+								.with("id", id2.toString())
+								.with("groupid", "gid2")
+								.with("requester", "n2")
+								.with("targetuser", "inv")
+								.with("type", "Invite to group")
+								.with("status", "Denied")
+								.with("createdate", 11000L)
+								.with("moddate", 26000L)
+								.with("expiredate", 21000L)
+								.build(),
+						MapBuilder.newHashMap()
+								.with("id", id1.toString())
+								.with("groupid", "gid1")
+								.with("requester", "n1")
+								.with("targetuser", null)
+								.with("type", "Request group membership")
+								.with("status", "Open")
+								.with("createdate", 10000L)
+								.with("moddate", 10000L)
+								.with("expiredate", 20000L)
+								.build()
+						)));
+	}
+
+	
+	@Test
+	public void toGroupRequestJSONListFail() throws Exception {
+		try {
+			APICommon.toGroupRequestJSON((List<GroupRequest>) null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("requests"));
+		}
+	}
+	
+	@Test
+	public void getToken() throws Exception {
+		assertThat("incorrect token", APICommon.getToken(null, false), is(nullValue()));
+		assertThat("incorrect token", APICommon.getToken("    \t   ", false), is(nullValue()));
+		assertThat("incorrect token", APICommon.getToken(" tok \t ", false), is(new Token("tok")));
+	}
+	
+	@Test
+	public void getTokenRequired() throws Exception {
+		assertThat("incorrect token", APICommon.getToken(" tok \t ", true), is(new Token("tok")));
+	}
+	
+	@Test
+	public void getTokenFail() throws Exception {
+		failGetToken(null, new NoTokenProvidedException("No token provided"));
+		failGetToken("   \t    ", new NoTokenProvidedException("No token provided"));
+	}
+	
+	private void failGetToken(final String token, final Exception expected) {
+		try {
+			APICommon.getToken(token, true);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+}

--- a/src/us/kbase/test/groups/service/api/APICommonTest.java
+++ b/src/us/kbase/test/groups/service/api/APICommonTest.java
@@ -150,12 +150,12 @@ public class APICommonTest {
 	public void getToken() throws Exception {
 		assertThat("incorrect token", APICommon.getToken(null, false), is(nullValue()));
 		assertThat("incorrect token", APICommon.getToken("    \t   ", false), is(nullValue()));
-		assertThat("incorrect token", APICommon.getToken(" tok \t ", false), is(new Token("tok")));
+		assertThat("incorrect token", APICommon.getToken("tok", false), is(new Token("tok")));
 	}
 	
 	@Test
 	public void getTokenRequired() throws Exception {
-		assertThat("incorrect token", APICommon.getToken(" tok \t ", true), is(new Token("tok")));
+		assertThat("incorrect token", APICommon.getToken("tok", true), is(new Token("tok")));
 	}
 	
 	@Test

--- a/src/us/kbase/test/groups/service/api/GroupsAPITest.java
+++ b/src/us/kbase/test/groups/service/api/GroupsAPITest.java
@@ -213,7 +213,7 @@ public class GroupsAPITest {
 	
 	@Test
 	public void getGroupWithToken() throws Exception {
-		getGroup("   foo   ", new Token("foo"));
+		getGroup("foo", new Token("foo"));
 	}
 	
 	private void getGroup(final String token, final Token expected) throws Exception {

--- a/src/us/kbase/test/groups/service/api/RequestAPITest.java
+++ b/src/us/kbase/test/groups/service/api/RequestAPITest.java
@@ -319,7 +319,7 @@ public class RequestAPITest {
 						.withStatus(GroupRequestStatus.canceled())
 						.build());
 		
-		final Map<String, Object> ret = new RequestAPI(g).cancelRequest("  tok  ", id.toString());
+		final Map<String, Object> ret = new RequestAPI(g).cancelRequest("tok", id.toString());
 		
 		assertThat("incorrect request", ret, is(MapBuilder.newHashMap()
 				.with("id", id.toString())
@@ -395,7 +395,7 @@ public class RequestAPITest {
 						.withStatus(GroupRequestStatus.accepted(new UserName("inv2")))
 						.build());
 		
-		final Map<String, Object> ret = new RequestAPI(g).acceptRequest("  tok  ", id.toString());
+		final Map<String, Object> ret = new RequestAPI(g).acceptRequest("tok", id.toString());
 		
 		assertThat("incorrect request", ret, is(MapBuilder.newHashMap()
 				.with("id", id.toString())
@@ -491,7 +491,7 @@ public class RequestAPITest {
 						.build());
 		
 		final Map<String, Object> ret = new RequestAPI(g).denyRequest(
-				"  tok  ", id.toString(), body);
+				"tok", id.toString(), body);
 		
 		assertThat("incorrect request", ret, is(MapBuilder.newHashMap()
 				.with("id", id.toString())


### PR DESCRIPTION
Also don't strip the token. The service shouldn't make assumptions about
token format, other than it's not null or just whitespace.