### PR TITLE
SCT-1486 Test core add member code

### DIFF
--- a/src/us/kbase/groups/core/Notifications.java
+++ b/src/us/kbase/groups/core/Notifications.java
@@ -13,8 +13,8 @@ public interface Notifications {
 
 	void cancel(RequestID requestID);
 
-	void deny(Set<UserName> targets, GroupRequest request, UserName deniedBy);
+	void deny(Set<UserName> targets, GroupRequest request);
 
-	void accept(Set<UserName> targets, GroupRequest request, UserName acceptedBy);
+	void accept(Set<UserName> targets, GroupRequest request);
 	
 }

--- a/src/us/kbase/groups/notifications/SLF4JNotifier.java
+++ b/src/us/kbase/groups/notifications/SLF4JNotifier.java
@@ -50,23 +50,19 @@ public class SLF4JNotifier implements Notifications {
 	}
 	
 	@Override
-	public void deny(
-			final Set<UserName> targets,
-			final GroupRequest request,
-			final UserName deniedBy) {
+	public void deny(final Set<UserName> targets, final GroupRequest request) {
 		LoggerFactory.getLogger(getClass()).info(String.format(
 				"User %s denied request %s, targets: %s",
-				deniedBy.getName(), request.getID().getID(), userNamesToStrings(targets)));
+				request.getClosedBy().get().getName(), request.getID().getID(),
+				userNamesToStrings(targets)));
 	}
 
 	@Override
-	public void accept(
-			final Set<UserName> targets,
-			final GroupRequest request,
-			final UserName acceptedBy) {
+	public void accept(final Set<UserName> targets, final GroupRequest request) {
 		LoggerFactory.getLogger(getClass()).info(String.format(
 				"User %s accepted request %s, targets: %s",
-				acceptedBy.getName(), request.getID().getID(), userNamesToStrings(targets)));
+				request.getClosedBy().get().getName(), request.getID().getID(),
+				userNamesToStrings(targets)));
 	}
 
 }


### PR DESCRIPTION
Notify based on updated request, not old request, which means redundant
username for user that closed request isn't needed. It's in the updated
request.