### PR TITLE
SCT-1486 Several changes to the workspace handler.

### DIFF
--- a/src/us/kbase/groups/core/workspace/WorkspaceHandler.java
+++ b/src/us/kbase/groups/core/workspace/WorkspaceHandler.java
@@ -15,4 +15,12 @@ public interface WorkspaceHandler {
 	WorkspaceInfoSet getWorkspaceInformation(WorkspaceIDSet ids, UserName user)
 			throws WorkspaceHandlerException;
 
+	// missing or deleted ws ids are not included in the returned set.
+	// always returns public workspaces regardless of bool
+	WorkspaceInfoSet getWorkspaceInformation(
+			WorkspaceIDSet ids,
+			UserName user,
+			boolean administratedWorkspacesOnly)
+			throws WorkspaceHandlerException;
+
 }

--- a/src/us/kbase/groups/core/workspace/WorkspaceInfoSet.java
+++ b/src/us/kbase/groups/core/workspace/WorkspaceInfoSet.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,12 +18,15 @@ public class WorkspaceInfoSet {
 	private final UserName user;
 	// might need to think about sorting here. YAGNI for now.
 	private final Map<WorkspaceInformation, Boolean> isAdmin;
+	private final Set<Integer> nonexistent;
 	
 	private WorkspaceInfoSet(
 			final UserName user,
-			final Map<WorkspaceInformation, Boolean> isAdmin) {
+			final Map<WorkspaceInformation, Boolean> isAdmin,
+			final Set<Integer> nonexistent) {
 		this.user = user;
 		this.isAdmin = Collections.unmodifiableMap(isAdmin);
+		this.nonexistent = Collections.unmodifiableSet(nonexistent);
 	}
 	
 	public UserName getUser() {
@@ -41,12 +45,17 @@ public class WorkspaceInfoSet {
 			return isAdmin.get(wsInfo);
 		}
 	}
+	
+	public Set<Integer> getNonexistentWorkspaces() {
+		return nonexistent;
+	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((isAdmin == null) ? 0 : isAdmin.hashCode());
+		result = prime * result + ((nonexistent == null) ? 0 : nonexistent.hashCode());
 		result = prime * result + ((user == null) ? 0 : user.hashCode());
 		return result;
 	}
@@ -70,6 +79,13 @@ public class WorkspaceInfoSet {
 		} else if (!isAdmin.equals(other.isAdmin)) {
 			return false;
 		}
+		if (nonexistent == null) {
+			if (other.nonexistent != null) {
+				return false;
+			}
+		} else if (!nonexistent.equals(other.nonexistent)) {
+			return false;
+		}
 		if (user == null) {
 			if (other.user != null) {
 				return false;
@@ -87,6 +103,8 @@ public class WorkspaceInfoSet {
 		builder2.append(user);
 		builder2.append(", isAdmin=");
 		builder2.append(isAdmin);
+		builder2.append(", nonexistant=");
+		builder2.append(nonexistent);
 		builder2.append("]");
 		return builder2.toString();
 	}
@@ -100,6 +118,7 @@ public class WorkspaceInfoSet {
 		private final UserName user;
 		// might need to think about sorting here. YAGNI for now.
 		private final Map<WorkspaceInformation, Boolean> isAdmin = new HashMap<>();
+		private final Set<Integer> nonexistent = new HashSet<>();
 		
 		public Builder(final UserName user) {
 			checkNotNull(user, "user");
@@ -114,8 +133,14 @@ public class WorkspaceInfoSet {
 			return this;
 		}
 		
+		public Builder withNonexistentWorkspace(final int wsid) {
+			checkNotNull(wsid, "wsid");
+			nonexistent.add(wsid);
+			return this;
+		}
+		
 		public WorkspaceInfoSet build() {
-			return new WorkspaceInfoSet(user, isAdmin);
+			return new WorkspaceInfoSet(user, isAdmin, nonexistent);
 		}
 	}
 }

--- a/src/us/kbase/groups/core/workspace/WorkspaceInformation.java
+++ b/src/us/kbase/groups/core/workspace/WorkspaceInformation.java
@@ -14,14 +14,17 @@ public class WorkspaceInformation {
 	private final int id;
 	private final String name;
 	private final Optional<String> narrativeName;
+	private final boolean isPublic;
 	
 	private WorkspaceInformation(
 			final int id,
 			final String name,
-			final Optional<String> narrativeName) {
+			final Optional<String> narrativeName,
+			final boolean isPublic) {
 		this.id = id;
 		this.name = name;
 		this.narrativeName = narrativeName;
+		this.isPublic = isPublic;
 	}
 
 	public int getId() {
@@ -35,12 +38,17 @@ public class WorkspaceInformation {
 	public Optional<String> getNarrativeName() {
 		return narrativeName;
 	}
+	
+	public boolean isPublic() {
+		return isPublic;
+	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + id;
+		result = prime * result + (isPublic ? 1231 : 1237);
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		result = prime * result + ((narrativeName == null) ? 0 : narrativeName.hashCode());
 		return result;
@@ -59,6 +67,9 @@ public class WorkspaceInformation {
 		}
 		WorkspaceInformation other = (WorkspaceInformation) obj;
 		if (id != other.id) {
+			return false;
+		}
+		if (isPublic != other.isPublic) {
 			return false;
 		}
 		if (name == null) {
@@ -87,6 +98,8 @@ public class WorkspaceInformation {
 		builder2.append(name);
 		builder2.append(", narrativeName=");
 		builder2.append(narrativeName);
+		builder2.append(", isPublic=");
+		builder2.append(isPublic);
 		builder2.append("]");
 		return builder2.toString();
 	}
@@ -100,6 +113,7 @@ public class WorkspaceInformation {
 		private final int id;
 		private final String name;
 		private Optional<String> narrativeName = Optional.absent();
+		private boolean isPublic = false;
 
 		private Builder(final int wsid, final String name) {
 			if (wsid < 1) {
@@ -119,8 +133,13 @@ public class WorkspaceInformation {
 			return this;
 		}
 		
+		public Builder withIsPublic(final boolean isPublic) {
+			this.isPublic = isPublic;
+			return this;
+		}
+		
 		public WorkspaceInformation build() {
-			return new WorkspaceInformation(id, name, narrativeName);
+			return new WorkspaceInformation(id, name, narrativeName, isPublic);
 		}
 	}
 


### PR DESCRIPTION
1) Allow filtering workspace sets by workspaces the user can administrate.
2) Always return public workspaces, even when filtering by administrated workspaces.
3) Include the public state in the information returned.
4) Include which workspaces were deleted or non-existent in the information returned. These will be removed from the group.
5) Simplify and slightly debug the information fetching code.
  This could could probably be a lot faster with some workspace updates, noted in TODOs.