### PR TITLE
SCT-1486 Add parameters for get requests by group to mongo layer

### DIFF
--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -48,6 +48,7 @@ import us.kbase.groups.core.workspace.WorkspaceHandler;
 import us.kbase.groups.core.workspace.WorkspaceID;
 import us.kbase.groups.core.workspace.WorkspaceIDSet;
 import us.kbase.groups.core.workspace.WorkspaceInfoSet;
+import us.kbase.groups.storage.GetRequestsParams;
 import us.kbase.groups.storage.GroupsStorage;
 import us.kbase.groups.storage.exceptions.GroupsStorageException;
 
@@ -448,7 +449,8 @@ public class Groups {
 					"User %s cannot view requests for group %s",
 					user.getName(), groupID.getName()));
 		}
-		return storage.getRequestsByGroup(groupID);
+		//TODO NOW pass params
+		return storage.getRequestsByGroup(groupID, GetRequestsParams.getBuilder().build());
 	}
 
 	private Group getGroupFromKnownGoodRequest(final GroupRequest request)

--- a/src/us/kbase/groups/storage/GetRequestsParams.java
+++ b/src/us/kbase/groups/storage/GetRequestsParams.java
@@ -1,0 +1,113 @@
+package us.kbase.groups.storage;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public class GetRequestsParams {
+
+	// TODO JAVADOC
+	// TODO TEST
+	
+	private final boolean includeClosed;
+	private final boolean sortAscending;
+	private final Optional<Instant> excludeUpTo;
+	
+	private GetRequestsParams(
+			final boolean includeClosed,
+			final boolean sortAscending,
+			final Optional<Instant> excludeUpTo) {
+		this.includeClosed = includeClosed;
+		this.sortAscending = sortAscending;
+		this.excludeUpTo = excludeUpTo;
+	}
+
+	public boolean isIncludeClosed() {
+		return includeClosed;
+	}
+
+	public boolean isSortAscending() {
+		return sortAscending;
+	}
+
+	public Optional<Instant> getExcludeUpTo() {
+		return excludeUpTo;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((excludeUpTo == null) ? 0 : excludeUpTo.hashCode());
+		result = prime * result + (includeClosed ? 1231 : 1237);
+		result = prime * result + (sortAscending ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		GetRequestsParams other = (GetRequestsParams) obj;
+		if (excludeUpTo == null) {
+			if (other.excludeUpTo != null) {
+				return false;
+			}
+		} else if (!excludeUpTo.equals(other.excludeUpTo)) {
+			return false;
+		}
+		if (includeClosed != other.includeClosed) {
+			return false;
+		}
+		if (sortAscending != other.sortAscending) {
+			return false;
+		}
+		return true;
+	}
+	
+	public static Builder getBuilder() {
+		return new Builder();
+	}
+	
+	public static class Builder {
+		
+		private boolean includeClosed = false;
+		private boolean sortAscending = true;
+		private Optional<Instant> excludeUpTo = Optional.empty();
+		
+		private Builder() {}
+		
+		public Builder withNullableIncludeClosed(final Boolean includeClosed) {
+			if (includeClosed == null) {
+				this.includeClosed = false;
+			} else {
+				this.includeClosed = includeClosed;
+			}
+			return this;
+		}
+		
+		public Builder withNullableSortAscending(final Boolean sortAscending) {
+			if (sortAscending == null) {
+				this.sortAscending = false;
+			} else {
+				this.sortAscending = sortAscending;
+			}
+			return this;
+		}
+		
+		public Builder withNullableExcludeUpTo(final Instant excludeUpTo) {
+			this.excludeUpTo = Optional.ofNullable(excludeUpTo);
+			return this;
+		}
+		
+		public GetRequestsParams build() {
+			return new GetRequestsParams(includeClosed, sortAscending, excludeUpTo);
+		}
+	}
+}

--- a/src/us/kbase/groups/storage/GroupsStorage.java
+++ b/src/us/kbase/groups/storage/GroupsStorage.java
@@ -19,6 +19,7 @@ import us.kbase.groups.core.exceptions.WorkspaceExistsException;
 import us.kbase.groups.core.request.GroupRequest;
 import us.kbase.groups.core.request.GroupRequestStatus;
 import us.kbase.groups.core.request.GroupRequestStatusType;
+import us.kbase.groups.core.request.GroupRequestType;
 import us.kbase.groups.core.request.RequestID;
 import us.kbase.groups.core.workspace.WorkspaceID;
 import us.kbase.groups.core.workspace.WorkspaceIDSet;
@@ -167,6 +168,7 @@ public interface GroupsStorage {
 	//TODO NOW need date range, limit & sort by date up /down if there's a lot
 	//TODO NOW allow getting closed requests
 	/** Get the open requests created by a user, sorted by the modification time of the request.
+	 * At most 100 requests are returned.
 	 * @param requester the user that created the requests.
 	 * @return the requests.
 	 * @throws GroupsStorageException if an error occurs contacting the storage system.
@@ -178,6 +180,7 @@ public interface GroupsStorage {
 	//TODO NOW allow getting closed requests
 	/** Get the open requests that target a user or the workspaces a user administrates,
 	 * sorted by the modification time of the request.
+	 * At most 100 requests are returned.
 	 * @param target the targeted user.
 	 * @param wsids the targeted workspaces for that user.
 	 * @return the requests.
@@ -186,15 +189,16 @@ public interface GroupsStorage {
 	List<GroupRequest> getRequestsByTarget(
 			UserName target, WorkspaceIDSet wsids) throws GroupsStorageException;
 
-	//TODO NOW need date range, limit & sort by date up /down if there's a lot
-	// only returns requests for that group specifically, e.g. no target user
-	//TODO NOW allow getting closed requests
 	/** Get the open requests that target a group, sorted by the modification time of the request.
+	 * At most 100 requests are returned.
+	 * Requests that target a group are {@link GroupRequestType#REQUEST_ADD_WORKSPACE} and
+	 * {@link GroupRequestType#REQUEST_GROUP_MEMBERSHIP}.
 	 * @param groupID the targeted group.
+	 * @param params the parameters for getting the requests.
 	 * @return the requests.
 	 * @throws GroupsStorageException if an error occurs contacting the storage system.
 	 */
-	List<GroupRequest> getRequestsByGroup(GroupID groupID)
+	List<GroupRequest> getRequestsByGroup(GroupID groupID, GetRequestsParams params)
 			throws GroupsStorageException;
 	
 	/** Close a request. WARNING: this function will allow setting the modification time to

--- a/src/us/kbase/test/groups/core/GroupsTest.java
+++ b/src/us/kbase/test/groups/core/GroupsTest.java
@@ -74,6 +74,7 @@ import us.kbase.groups.core.workspace.WorkspaceIDSet;
 import us.kbase.groups.core.workspace.WorkspaceInfoSet;
 import us.kbase.groups.core.workspace.WorkspaceInformation;
 import us.kbase.groups.core.workspace.WorkspacePermission;
+import us.kbase.groups.storage.GetRequestsParams;
 import us.kbase.groups.storage.GroupsStorage;
 import us.kbase.test.groups.TestCommon;
 
@@ -1620,7 +1621,8 @@ public class GroupsTest {
 				.withMember(new UserName("u1"))
 				.withMember(new UserName("u3"))
 				.build());
-		when(mocks.storage.getRequestsByGroup(new GroupID("gid")))
+		when(mocks.storage.getRequestsByGroup(
+				new GroupID("gid"), GetRequestsParams.getBuilder().build()))
 				.thenReturn(Collections.emptyList());
 		
 		assertThat("incorrect requests", mocks.groups.getRequestsForGroup(
@@ -1640,23 +1642,26 @@ public class GroupsTest {
 				.withMember(new UserName("u1"))
 				.withMember(new UserName("u3"))
 				.build());
-		when(mocks.storage.getRequestsByGroup(new GroupID("gid"))).thenReturn(Arrays.asList(
-				GroupRequest.getBuilder(
-						new RequestID(id1), new GroupID("gid"), new UserName("user"),
-						CreateModAndExpireTimes.getBuilder(
-								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withRequestGroupMembership()
-						.build(),
-				GroupRequest.getBuilder(
-						new RequestID(id2), new GroupID("gid"), new UserName("user"),
-						CreateModAndExpireTimes.getBuilder(
-								Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
-								.withModificationTime(Instant.ofEpochMilli(25000))
-								.build())
-						.withRequestGroupMembership()
-						.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
-						.build()
-				));
+		when(mocks.storage.getRequestsByGroup(
+				new GroupID("gid"), GetRequestsParams.getBuilder().build()))
+				.thenReturn(Arrays.asList(
+						GroupRequest.getBuilder(
+								new RequestID(id1), new GroupID("gid"), new UserName("user"),
+								CreateModAndExpireTimes.getBuilder(
+										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
+										.build())
+								.withRequestGroupMembership()
+								.build(),
+						GroupRequest.getBuilder(
+								new RequestID(id2), new GroupID("gid"), new UserName("user"),
+								CreateModAndExpireTimes.getBuilder(
+										Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
+										.withModificationTime(Instant.ofEpochMilli(25000))
+										.build())
+								.withRequestGroupMembership()
+								.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
+								.build()
+						));
 		
 		assertThat("incorrect requests", mocks.groups.getRequestsForGroup(
 				new Token("token"), new GroupID("gid")),


### PR DESCRIPTION
- change sort order (sorted by mod date)
- include closed requests
- set a date to exclude earlier or later requests, depending on sort
order