### PR TITLE
SCT-1486 Don't allow resource duplicates in groups

### DIFF
--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -884,6 +884,7 @@ public class Groups {
 		final Group g = storage.getGroup(groupID);
 		final ResourceHandler h = getHandler(type);
 		final ResourceDescriptor d = h.getDescriptor(resource);
+		//TODO NNOW change to test on ID, not descriptor
 		if (g.containsResource(type, d)) {
 			throw new ResourceExistsException(resource.getName());
 		}


### PR DESCRIPTION
Even if they have different admin IDs. That breaks the admin ID
contract.

also add some helper methods.