### PR TITLE
SCT-1486 Only provide resourceID when removing resources from mongo

### DIFF
--- a/src/us/kbase/groups/core/Group.java
+++ b/src/us/kbase/groups/core/Group.java
@@ -159,7 +159,7 @@ public class Group {
 	public ResourceDescriptor getResource(final ResourceType type, final ResourceID resourceID) {
 		checkNotNull(type, "type");
 		checkNotNull(resourceID, "resourceID");
-		if (!resources.containsKey(type) || !resources.get(type).containsKey(resourceID)) {
+		if (!containsResource(type, resourceID)) {
 			throw new IllegalArgumentException(String.format("No such resource %s %s",
 					type.getName(), resourceID.getName()));
 		}

--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -272,7 +272,7 @@ public class Groups {
 		b.withResource(type, info);
 		for (final ResourceDescriptor d: info.getNonexistentResources()) {
 			try {
-				storage.removeResource(g.getGroupID(), type, d, clock.instant());
+				storage.removeResource(g.getGroupID(), type, d.getResourceID(), clock.instant());
 			} catch (NoSuchResourceException e) {
 				// do nothing, if the resource isn't there fine.
 			}
@@ -938,10 +938,10 @@ public class Groups {
 		final UserName user = userHandler.getUser(userToken);
 		final Group group = storage.getGroup(groupID);
 		final ResourceHandler h = getHandler(type);
-		final ResourceDescriptor d = h.getDescriptor(resource);
+		h.getDescriptor(resource); // check that the id is valid
 		// should check if ws not in group & fail early?
 		if (group.isAdministrator(user) || h.isAdministrator(resource, user)) {
-			storage.removeResource(groupID, type, d, clock.instant());
+			storage.removeResource(groupID, type, resource, clock.instant());
 		} else {
 			throw new UnauthorizedException(String.format(
 					"User %s is not an admin for group %s or %s %s",

--- a/src/us/kbase/groups/storage/GroupsStorage.java
+++ b/src/us/kbase/groups/storage/GroupsStorage.java
@@ -27,6 +27,7 @@ import us.kbase.groups.core.request.RequestID;
 import us.kbase.groups.core.request.RequestType;
 import us.kbase.groups.core.resource.ResourceAdministrativeID;
 import us.kbase.groups.core.resource.ResourceDescriptor;
+import us.kbase.groups.core.resource.ResourceID;
 import us.kbase.groups.core.resource.ResourceType;
 import us.kbase.groups.storage.exceptions.GroupsStorageException;
 
@@ -146,7 +147,7 @@ public interface GroupsStorage {
 	/** Remove a resource from a group.
 	 * @param groupID the group ID.
 	 * @param type the resource type.
-	 * @param resource the resource descriptor.
+	 * @param resource the resource ID.
 	 * @param modDate the modification date to apply to the group.
 	 * @throws NoSuchGroupException if there is no group with the given ID.
 	 * @throws GroupsStorageException if an error occurs contacting the storage system.
@@ -155,7 +156,7 @@ public interface GroupsStorage {
 	void removeResource(
 			GroupID groupID,
 			ResourceType type,
-			ResourceDescriptor resource,
+			ResourceID resource,
 			Instant modDate)
 			throws NoSuchGroupException, GroupsStorageException, NoSuchResourceException;
 	

--- a/src/us/kbase/test/groups/core/GroupsTest.java
+++ b/src/us/kbase/test/groups/core/GroupsTest.java
@@ -685,13 +685,13 @@ public class GroupsTest {
 		when(mocks.clock.instant()).thenReturn(inst(5600));
 		doThrow(new NoSuchResourceException("86")).when(mocks.storage)
 				.removeResource(new GroupID("bar"), new ResourceType("workspace"),
-						new ResourceDescriptor(new ResourceID("86")), inst(5600));
+						new ResourceID("86"), inst(5600));
 		
 		
 		final GroupView g = mocks.groups.getGroup(new Token("token"), new GroupID("bar"));
 		
 		verify(mocks.storage).removeResource(new GroupID("bar"), new ResourceType("workspace"),
-				new ResourceDescriptor(new ResourceID("34")), inst(5600));
+				new ResourceID("34"), inst(5600));
 		
 		assertThat("incorrect group", g, is(GroupView.getBuilder(Group.getBuilder(
 				new GroupID("bar"), new GroupName("name"), new UserName("foo"),
@@ -3875,7 +3875,7 @@ public class GroupsTest {
 		verify(mocks.storage).removeResource(
 				new GroupID("gid"),
 				new ResourceType("workspace"),
-				new ResourceDescriptor(new ResourceID("34")),
+				new ResourceID("34"),
 				inst(7100));
 	}
 	
@@ -3903,7 +3903,7 @@ public class GroupsTest {
 		verify(mocks.storage).removeResource(
 				new GroupID("gid"),
 				new ResourceType("workspace"),
-				new ResourceDescriptor(new ResourceID("34")),
+				new ResourceID("34"),
 				inst(7500));
 	}
 	
@@ -4023,7 +4023,7 @@ public class GroupsTest {
 				.removeResource(
 						new GroupID("gid"),
 						new ResourceType("workspace"),
-						new ResourceDescriptor(new ResourceID("34")),
+						new ResourceID("34"),
 						inst(7000));
 		
 		failRemoveResource(mocks.groups, new Token("t"), new GroupID("gid"),

--- a/src/us/kbase/test/groups/storage/mongo/MongoGroupsStorageOpsTest.java
+++ b/src/us/kbase/test/groups/storage/mongo/MongoGroupsStorageOpsTest.java
@@ -1320,8 +1320,7 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.removeResource(
 				new GroupID("gid"),
 				new ResourceType("ws"),
-				new ResourceDescriptor(
-						new ResourceAdministrativeID("a"), new ResourceID("c")),
+				new ResourceID("c"),
 				inst(109200));
 		
 		assertThat("incorrect group", manager.storage.getGroup(new GroupID("gid")), is(
@@ -1333,14 +1332,10 @@ public class MongoGroupsStorageOpsTest {
 								new ResourceAdministrativeID("a"), new ResourceID("b")))
 						.build()));
 		
-		// since each resource ID should always have the same admin ID, just remove the
-		// resource based on the resource ID. If the admin ID changes there's something very
-		// wrong, but not allowing a removal of the resource is a bad idea
 		manager.storage.removeResource(
 				new GroupID("gid"),
 				new ResourceType("ws"),
-				new ResourceDescriptor(
-						new ResourceAdministrativeID("b"), new ResourceID("b")),
+				new ResourceID("b"),
 				inst(119200));
 		
 		assertThat("incorrect group", manager.storage.getGroup(new GroupID("gid")), is(
@@ -1355,7 +1350,7 @@ public class MongoGroupsStorageOpsTest {
 	public void removeResourceFailNulls() throws Exception {
 		final GroupID g = new GroupID("g");
 		final ResourceType t = new ResourceType("t");
-		final ResourceDescriptor d = new ResourceDescriptor(new ResourceID("i"));
+		final ResourceID d = new ResourceID("i");
 		
 		failRemoveResource(null, t, d, inst(1), new NullPointerException("groupID"));
 		failRemoveResource(g, null, d, inst(1), new NullPointerException("type"));
@@ -1373,7 +1368,7 @@ public class MongoGroupsStorageOpsTest {
 		failRemoveResource(
 				new GroupID("gid1"),
 				new ResourceType("t"),
-				new ResourceDescriptor(new ResourceID("id")),
+				new ResourceID("id"),
 				inst(1),
 				new NoSuchGroupException("gid1"));
 		
@@ -1392,8 +1387,7 @@ public class MongoGroupsStorageOpsTest {
 		failRemoveResource(
 				new GroupID("gid"),
 				new ResourceType("ws"),
-				new ResourceDescriptor(
-						new ResourceAdministrativeID("a"), new ResourceID("c")),
+				new ResourceID("c"),
 				inst(1),
 				new NoSuchResourceException("Group gid does not include ws c"));
 		
@@ -1403,7 +1397,7 @@ public class MongoGroupsStorageOpsTest {
 	private void failRemoveResource(
 			final GroupID g,
 			final ResourceType t,
-			final ResourceDescriptor d,
+			final ResourceID d,
 			final Instant modDate,
 			final Exception expected) {
 		try {


### PR DESCRIPTION
No need for entire descriptor.