### PR TITLE
SCT-1486 Add public & minimal view config items to validator config

### DIFF
--- a/src/us/kbase/groups/config/GroupsConfig.java
+++ b/src/us/kbase/groups/config/GroupsConfig.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.ini4j.Ini;
@@ -185,8 +186,14 @@ public class GroupsConfig {
 			final String valclass = getString(pre + KEY_SUFFIX_FIELD_VALIDATOR, cfg, true);
 			final boolean isNumbered = TRUE.equals(
 					getString(pre + KEY_SUFFIX_FIELD_IS_NUMBERED, cfg));
-			configs.add(new FieldValidatorConfiguration(
-					field, valclass, isNumbered, getParams(pre + KEY_SUFFIX_FIELD_PARAM, cfg)));
+			final Map<String, String> params = getParams(pre + KEY_SUFFIX_FIELD_PARAM, cfg);
+			final FieldValidatorConfiguration.Builder b = FieldValidatorConfiguration
+					.getBuilder(field, valclass)
+					.withNullableIsNumberedField(isNumbered);
+			for (final Entry<String, String> e: params.entrySet()) {
+				b.withConfigurationEntry(e.getKey(), e.getValue());
+			}
+			configs.add(b.build());
 		}
 		return Collections.unmodifiableSet(configs);
 	}

--- a/src/us/kbase/test/groups/config/GroupsConfigTest.java
+++ b/src/us/kbase/test/groups/config/GroupsConfigTest.java
@@ -151,17 +151,20 @@ public class GroupsConfigTest {
 		assertThat("incorrect allow insecure", cfg.isAllowInsecureURLs(), is(false));
 		assertThat("incorrect ignore ip headers", cfg.isIgnoreIPHeaders(), is(false));
 		assertThat("incorrect fields", cfg.getFieldConfigurations(), is(set(
-				new FieldValidatorConfiguration(new CustomField("foo"), "foovalclass", false,
-						Collections.emptyMap()),
-				new FieldValidatorConfiguration(new CustomField("bar"), "barvalclass", false,
-						ImmutableMap.of("p1", "p1val", "p2", "p2val")),
-				new FieldValidatorConfiguration(new CustomField("baz"), "bazvalclass", true,
-						Collections.emptyMap()))));
+				FieldValidatorConfiguration.getBuilder(new CustomField("foo"), "foovalclass")
+						.build(),
+				FieldValidatorConfiguration.getBuilder(new CustomField("bar"), "barvalclass")
+						.withConfigurationEntry("p1", "p1val")
+						.withConfigurationEntry("p2", "p2val")
+						.build(),
+				FieldValidatorConfiguration.getBuilder(new CustomField("baz"), "bazvalclass")
+						.withNullableIsNumberedField(true)
+						.build())));
 		testLogger(cfg.getLogger(), false);
 		
 		try {
-			cfg.getFieldConfigurations().add(new FieldValidatorConfiguration(
-					new CustomField("f"), "c", false, Collections.emptyMap()));
+			cfg.getFieldConfigurations().add(FieldValidatorConfiguration.getBuilder(
+					new CustomField("f"), "c").build());
 			fail("expected exception");
 		} catch (UnsupportedOperationException e) {
 			// is immutable, test passes


### PR DESCRIPTION
Make a validator config, too many constructor arguments.

Next:
- add to config file processor & docs
- add to FieldValidators.java
- use in Group view (pass in fn?)