### PR TITLE
SCT-1486 Switch custom fields from a 3 value class to a 2 value class

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -281,6 +281,7 @@
         <test name="us.kbase.test.groups.core.GroupViewTest"/>
         <test name="us.kbase.test.groups.core.NameTest"/>
         <test name="us.kbase.test.groups.core.OptionalGroupFieldsTest"/>
+        <test name="us.kbase.test.groups.core.OptionalStringTest"/>
         <test name="us.kbase.test.groups.core.TokenTest"/>
         <test name="us.kbase.test.groups.core.UserNameTest"/>
         <test name="us.kbase.test.groups.core.fieldvalidation.CustomFieldTest"/>

--- a/src/us/kbase/groups/core/GroupCreationParams.java
+++ b/src/us/kbase/groups/core/GroupCreationParams.java
@@ -55,7 +55,7 @@ public class GroupCreationParams {
 				groupID, groupName, GroupUser.getBuilder(owner, times.getCreationTime()).build(),
 				times)
 				.withDescription(opfields.getDescription().orNull());
-		opfields.getCustomFields().stream().filter(f -> opfields.getCustomValue(f).hasItem())
+		opfields.getCustomFields().stream().filter(f -> opfields.getCustomValue(f).isPresent())
 				.forEach(f -> b.withCustomField(f, opfields.getCustomValue(f).get()));
 		return b.build();
 	}

--- a/src/us/kbase/groups/core/OptionalGroupFields.java
+++ b/src/us/kbase/groups/core/OptionalGroupFields.java
@@ -20,11 +20,11 @@ import us.kbase.groups.core.fieldvalidation.NumberedCustomField;
 public class OptionalGroupFields {
 	
 	private final FieldItem<String> description;
-	private final Map<NumberedCustomField, FieldItem<String>> customFields;
+	private final Map<NumberedCustomField, OptionalString> customFields;
 
 	private OptionalGroupFields(
 			final FieldItem<String> description,
-			final Map<NumberedCustomField, FieldItem<String>> customFields) {
+			final Map<NumberedCustomField, OptionalString> customFields) {
 		this.description = description;
 		this.customFields = Collections.unmodifiableMap(customFields);
 	}
@@ -36,15 +36,11 @@ public class OptionalGroupFields {
 		return description;
 	}
 	
-	/** True if for any of the items {@link FieldItem#hasAction()} is true, false otherwise.
+	/** Returns true if at least one field require an update.
 	 * @return if a field requires an update.
 	 */
 	public boolean hasUpdate() {
-		boolean hasUpdate = false;
-		for (final FieldItem<String> s: customFields.values()) {
-			hasUpdate = hasUpdate || s.hasAction();
-		}
-		return description.hasAction() || hasUpdate;
+		return description.hasAction() || !customFields.isEmpty();
 	}
 	
 	/** Get any custom fields included in the fields.
@@ -58,7 +54,7 @@ public class OptionalGroupFields {
 	 * @param field the field.
 	 * @return the value.
 	 */
-	public FieldItem<String> getCustomValue(final NumberedCustomField field) {
+	public OptionalString getCustomValue(final NumberedCustomField field) {
 		checkNotNull(field, "field");
 		if (!customFields.containsKey(field)) {
 			throw new IllegalArgumentException("No such field " + field.getField());
@@ -126,7 +122,7 @@ public class OptionalGroupFields {
 	public static class Builder {
 
 		private FieldItem<String> description = FieldItem.noAction();
-		private final Map<NumberedCustomField, FieldItem<String>> customFields = new HashMap<>();
+		private final Map<NumberedCustomField, OptionalString> customFields = new HashMap<>();
 		
 		private Builder() {}
 		
@@ -151,14 +147,15 @@ public class OptionalGroupFields {
 			return this;
 		}
 		
-		// TODO CODE there's no need for StringField here. Absent = no change, Optional.empty() == remove
-		// except that Optional allows whitespace only strings, bleah. Maybe a StringOptional class?
 		/** Add a custom field to the set of fields.
 		 * @param field the field.
-		 * @param value the value of the field.
+		 * @param value the value of the field. An {@link OptionalString#empty()} value indicates
+		 * the field should be removed.
 		 * @return this builder.
 		 */
-		public Builder withCustomField(final NumberedCustomField field, final StringField value) {
+		public Builder withCustomField(
+				final NumberedCustomField field,
+				final OptionalString value) {
 			checkNotNull(field, "field");
 			checkNotNull(value, "value");
 			customFields.put(field, value);

--- a/src/us/kbase/groups/core/OptionalString.java
+++ b/src/us/kbase/groups/core/OptionalString.java
@@ -1,0 +1,113 @@
+package us.kbase.groups.core;
+
+import static us.kbase.groups.util.Util.isNullOrEmpty;
+import static us.kbase.groups.util.Util.exceptOnEmpty;
+
+import java.util.Optional;
+
+/** A {@link String} specific version of {@link Optional}. 
+ * 
+ * The differences are that strings that are whitespace-only are treated as {@link #empty()} and
+ * and whitespace is {@link String#trim()}ed from non-null non-whitespace-only values.
+ * @author gaprice@lbl.gov
+ *
+ */
+public final class OptionalString {
+	
+	// TODO CODE add more methods from Optional as needed.
+
+	private final String value;
+	
+	private OptionalString(final String value) {
+		this.value = value;
+	}
+	
+	/** Create an empty {@link OptionalString}.
+	 * @return the empty String, where empty in this case means no value.
+	 */
+	public static OptionalString empty() {
+		return new OptionalString(null);
+	}
+	
+	/** Create a new {@link OptionalString}. 
+	 * @param value the value, which cannot be null or whitespace-only.
+	 * @return the new string.
+	 */
+	public static OptionalString of(final String value) {
+		exceptOnEmpty(value, "value");
+		return new OptionalString(value.trim());
+	}
+	
+	/** Create a new {@link OptionalString} from a value which may be null or whitespace-only.
+	 * @param value the value.
+	 * @return {@link #empty()} if the value is null or whitespace only, or {@link #of(String)}
+	 * otherwise. The value is {@link String#trim()}ed.
+	 */
+	public static OptionalString ofEmptyable(final String value) {
+		return isNullOrEmpty(value) ? empty() : of(value);
+	}
+	
+	/** Get whether a value for the optional string exists.
+	 * @return true if a value exists.
+	 */
+	public boolean isPresent() {
+		return value != null;
+	}
+	
+	/** Get the value, which must be present.
+	 * @throws IllegalStateException if there is no value.
+	 * @return the value.
+	 */
+	public String get() {
+		if (value == null) {
+			throw new IllegalStateException("Cannot call get() on an empty OptionalString");
+		}
+		return value;
+	}
+	
+	/** Returns the string value or null if no value is present.
+	 * @return the value or null.
+	 */
+	public String orNull() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		if (isPresent()) {
+			return "OptionalString[" + value + "]";
+		} else {
+			return "OptionalString.empty";
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		OptionalString other = (OptionalString) obj;
+		if (value == null) {
+			if (other.value != null) {
+				return false;
+			}
+		} else if (!value.equals(other.value)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/us/kbase/groups/storage/GroupsStorage.java
+++ b/src/us/kbase/groups/storage/GroupsStorage.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import us.kbase.groups.core.FieldItem.StringField;
 import us.kbase.groups.core.GetGroupsParams;
 import us.kbase.groups.core.GetRequestsParams;
 import us.kbase.groups.core.Group;
@@ -13,6 +12,7 @@ import us.kbase.groups.core.GroupID;
 import us.kbase.groups.core.GroupUpdateParams;
 import us.kbase.groups.core.GroupUser;
 import us.kbase.groups.core.Groups;
+import us.kbase.groups.core.OptionalString;
 import us.kbase.groups.core.UserName;
 import us.kbase.groups.core.exceptions.GroupExistsException;
 import us.kbase.groups.core.exceptions.NoSuchGroupException;
@@ -136,7 +136,8 @@ public interface GroupsStorage {
 	/** Update user properties.
 	 * @param groupID the ID of the group to update.
 	 * @param member the user to update.
-	 * @param fields the fields to update.
+	 * @param fields the fields to update. An {@link OptionalString#empty()} value indicates
+	 * the field should be removed.
 	 * @param modDate the modification date to apply to the group.
 	 * @throws NoSuchGroupException if there is no group with the given ID.
 	 * @throws NoSuchUserException if the user is not a member of the group.
@@ -145,7 +146,7 @@ public interface GroupsStorage {
 	void updateUser(
 			GroupID groupID,
 			UserName member,
-			Map<NumberedCustomField, StringField> fields,
+			Map<NumberedCustomField, OptionalString> fields,
 			Instant modDate)
 			throws NoSuchGroupException, GroupsStorageException, NoSuchUserException;
 	

--- a/src/us/kbase/test/groups/core/GroupCreationParamsTest.java
+++ b/src/us/kbase/test/groups/core/GroupCreationParamsTest.java
@@ -18,6 +18,7 @@ import us.kbase.groups.core.GroupID;
 import us.kbase.groups.core.GroupName;
 import us.kbase.groups.core.GroupUser;
 import us.kbase.groups.core.OptionalGroupFields;
+import us.kbase.groups.core.OptionalString;
 import us.kbase.groups.core.UserName;
 import us.kbase.groups.core.fieldvalidation.NumberedCustomField;
 import us.kbase.groups.core.FieldItem.StringField;
@@ -50,9 +51,9 @@ public class GroupCreationParamsTest {
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.fromNullable("    my desc    "))
 						.withCustomField(new NumberedCustomField("whee-1"),
-								StringField.from("he bit my widdle nose"))
+								OptionalString.of("he bit my widdle nose"))
 						.withCustomField(new NumberedCustomField("whee-2"),
-								StringField.from("oh you brute"))
+								OptionalString.of("oh you brute"))
 						.build())
 				.build();
 		
@@ -61,9 +62,9 @@ public class GroupCreationParamsTest {
 		assertThat("incorrect desc", p.getOptionalFields(), is(OptionalGroupFields.getBuilder()
 				.withDescription(StringField.from("my desc"))
 				.withCustomField(new NumberedCustomField("whee-1"),
-						StringField.from("he bit my widdle nose"))
+						OptionalString.of("he bit my widdle nose"))
 				.withCustomField(new NumberedCustomField("whee-2"),
-						StringField.from("oh you brute"))
+						OptionalString.of("oh you brute"))
 				.build()));
 	}
 
@@ -125,9 +126,8 @@ public class GroupCreationParamsTest {
 				new GroupID("id"), new GroupName("name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("yay"))
-						.withCustomField(new NumberedCustomField("foo"), StringField.from("bar"))
-						.withCustomField(new NumberedCustomField("foo-1"), StringField.remove())
-						.withCustomField(new NumberedCustomField("foo-1"), StringField.noAction())
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.of("bar"))
+						.withCustomField(new NumberedCustomField("foo-1"), OptionalString.empty())
 						.build())
 				.build();
 		

--- a/src/us/kbase/test/groups/core/GroupsTest.java
+++ b/src/us/kbase/test/groups/core/GroupsTest.java
@@ -42,6 +42,7 @@ import us.kbase.groups.core.GroupUser;
 import us.kbase.groups.core.GroupView;
 import us.kbase.groups.core.Groups;
 import us.kbase.groups.core.OptionalGroupFields;
+import us.kbase.groups.core.OptionalString;
 import us.kbase.groups.core.Token;
 import us.kbase.groups.core.UUIDGenerator;
 import us.kbase.groups.core.UserHandler;
@@ -254,9 +255,8 @@ public class GroupsTest {
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("desc"))
 						.withCustomField(new NumberedCustomField("foo-26"),
-								StringField.from("yay"))
-						.withCustomField(new NumberedCustomField("a"), StringField.remove())
-						.withCustomField(new NumberedCustomField("b"), StringField.noAction())
+								OptionalString.of("yay"))
+						.withCustomField(new NumberedCustomField("a"), OptionalString.empty())
 						.build())
 				.build());
 		
@@ -311,7 +311,7 @@ public class GroupsTest {
 		failCreateGroup(mocks.groups, new Token("token"), GroupCreationParams
 				.getBuilder(new GroupID("bar"), new GroupName("name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withCustomField(new NumberedCustomField("var"), StringField.from("7"))
+						.withCustomField(new NumberedCustomField("var"), OptionalString.of("7"))
 						.build())
 				.build(),
 				new NoSuchCustomFieldException("var"));
@@ -328,7 +328,7 @@ public class GroupsTest {
 		failCreateGroup(mocks.groups, new Token("token"), GroupCreationParams
 				.getBuilder(new GroupID("bar"), new GroupName("name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withCustomField(new NumberedCustomField("var"), StringField.from("7"))
+						.withCustomField(new NumberedCustomField("var"), OptionalString.of("7"))
 						.build())
 				.build(),
 				new RuntimeException(
@@ -422,9 +422,8 @@ public class GroupsTest {
 				.withName(new GroupName("new name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withCustomField(new NumberedCustomField("foo-26"),
-								StringField.from("yay"))
-						.withCustomField(new NumberedCustomField("a"), StringField.remove())
-						.withCustomField(new NumberedCustomField("b"), StringField.noAction())
+								OptionalString.of("yay"))
+						.withCustomField(new NumberedCustomField("a"), OptionalString.empty())
 						.build())
 				.build());
 		
@@ -435,9 +434,8 @@ public class GroupsTest {
 				.withName(new GroupName("new name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withCustomField(new NumberedCustomField("foo-26"),
-								StringField.from("yay"))
-						.withCustomField(new NumberedCustomField("a"), StringField.remove())
-						.withCustomField(new NumberedCustomField("b"), StringField.noAction())
+								OptionalString.of("yay"))
+						.withCustomField(new NumberedCustomField("a"), OptionalString.empty())
 						.build())
 				.build(),
 				inst(30000));
@@ -462,7 +460,7 @@ public class GroupsTest {
 		failUpdateGroup(mocks.groups, new Token("token"), GroupUpdateParams
 				.getBuilder(new GroupID("bar"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withCustomField(new NumberedCustomField("var"), StringField.from("7"))
+						.withCustomField(new NumberedCustomField("var"), OptionalString.of("7"))
 						.build())
 				.build(),
 				new RuntimeException(
@@ -479,7 +477,7 @@ public class GroupsTest {
 		failUpdateGroup(mocks.groups, new Token("token"), GroupUpdateParams
 				.getBuilder(new GroupID("bar"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withCustomField(new NumberedCustomField("var"), StringField.from("7"))
+						.withCustomField(new NumberedCustomField("var"), OptionalString.of("7"))
 						.build())
 				.build(),
 				new IllegalParameterException("foo"));
@@ -543,20 +541,18 @@ public class GroupsTest {
 		when(mocks.clock.instant()).thenReturn(inst(25000));
 		
 		mocks.groups.updateUser(new Token("t"), new GroupID("gid"), target,
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1"),
-						new NumberedCustomField("f2"), StringField.from("val2"),
-						new NumberedCustomField("f3"), StringField.remove(),
-						new NumberedCustomField("f4"), StringField.noAction()));
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1"),
+						new NumberedCustomField("f2"), OptionalString.of("val2"),
+						new NumberedCustomField("f3"), OptionalString.empty()));
 		
 		verify(mocks.validators).validateUserField(new NumberedCustomField("f-1"), "val1");
 		verify(mocks.validators).validateUserField(new NumberedCustomField("f2"), "val2");
 		verifyNoMoreInteractions(mocks.validators);
 		
 		verify(mocks.storage).updateUser(new GroupID("gid"), target,
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1"),
-						new NumberedCustomField("f2"), StringField.from("val2"),
-						new NumberedCustomField("f3"), StringField.remove(),
-						new NumberedCustomField("f4"), StringField.noAction()),
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1"),
+						new NumberedCustomField("f2"), OptionalString.of("val2"),
+						new NumberedCustomField("f3"), OptionalString.empty()),
 				inst(25000));
 	}
 	
@@ -584,19 +580,17 @@ public class GroupsTest {
 		when(mocks.clock.instant()).thenReturn(inst(25000));
 		
 		mocks.groups.updateUser(new Token("t"), new GroupID("gid"), new UserName("member"),
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1"),
-						new NumberedCustomField("f2"), StringField.from("val2"),
-						new NumberedCustomField("f3"), StringField.remove(),
-						new NumberedCustomField("f4"), StringField.noAction()));
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1"),
+						new NumberedCustomField("f2"), OptionalString.of("val2"),
+						new NumberedCustomField("f3"), OptionalString.empty()));
 		
 		verify(mocks.validators).validateUserField(new NumberedCustomField("f-1"), "val1");
 		verify(mocks.validators).validateUserField(new NumberedCustomField("f2"), "val2");
 		
 		verify(mocks.storage).updateUser(new GroupID("gid"), new UserName("member"),
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1"),
-						new NumberedCustomField("f2"), StringField.from("val2"),
-						new NumberedCustomField("f3"), StringField.remove(),
-						new NumberedCustomField("f4"), StringField.noAction()),
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1"),
+						new NumberedCustomField("f2"), OptionalString.of("val2"),
+						new NumberedCustomField("f3"), OptionalString.empty()),
 				inst(25000));
 	}
 	
@@ -608,27 +602,19 @@ public class GroupsTest {
 	}
 	
 	@Test
-	public void updateUserNoUpdateNoAction() throws Exception {
-		// nothing should happen
-		initTestMocks().groups.updateUser(new Token("t"), new GroupID("i"), new UserName("n"),
-				ImmutableMap.of(new NumberedCustomField("f"), StringField.noAction(),
-						new NumberedCustomField("f2"), StringField.noAction()));
-	}
-	
-	@Test
 	public void updateUserFailNulls() throws Exception {
 		final Groups g = initTestMocks().groups;
 		final Token t = new Token("t");
 		final GroupID gid = new GroupID("g");
 		final UserName n = new UserName("n");
-		final Map<NumberedCustomField, StringField> f = new HashMap<>();
+		final Map<NumberedCustomField, OptionalString> f = new HashMap<>();
 		
 		updateUserFail(g, null, gid, n, f, new NullPointerException("userToken"));
 		updateUserFail(g, t, null, n, f, new NullPointerException("groupID"));
 		updateUserFail(g, t, gid, null, f, new NullPointerException("member"));
 		updateUserFail(g, t, gid, n, null, new NullPointerException("fields"));
 		
-		f.put(null, StringField.remove());
+		f.put(null, OptionalString.empty());
 		updateUserFail(g, t, gid, n, f, new NullPointerException("Null key in fields"));
 		
 		f.clear();
@@ -682,7 +668,7 @@ public class GroupsTest {
 				.build());
 		
 		updateUserFail(mocks.groups, new Token("t"), new GroupID("gid"), target,
-				ImmutableMap.of(new NumberedCustomField("f"), StringField.remove()),
+				ImmutableMap.of(new NumberedCustomField("f"), OptionalString.empty()),
 				expected);
 	}
 
@@ -705,7 +691,7 @@ public class GroupsTest {
 				.when(mocks.validators).validateUserField(new NumberedCustomField("f-1"), "val1");
 		
 		updateUserFail(mocks.groups, new Token("t"), new GroupID("gid"), new UserName("member"),
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1")),
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1")),
 				new RuntimeException(
 						"This should be impossible. Please turn reality off and on again"));
 	}
@@ -728,7 +714,7 @@ public class GroupsTest {
 				.when(mocks.validators).validateUserField(new NumberedCustomField("f-1"), "val1");
 		
 		updateUserFail(mocks.groups, new Token("t"), new GroupID("gid"), new UserName("member"),
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1")),
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1")),
 				new IllegalParameterException("bar"));
 	}
 	
@@ -754,9 +740,9 @@ public class GroupsTest {
 		when(mocks.validators.getUserFieldConfiguration(new CustomField("f3"))).thenReturn(uset);
 		
 		updateUserFail(mocks.groups, new Token("t"), new GroupID("gid"), new UserName("member"),
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.from("val1"),
-						new NumberedCustomField("f2"), StringField.from("val2"),
-						new NumberedCustomField("f3"), StringField.remove()),
+				ImmutableMap.of(new NumberedCustomField("f-1"), OptionalString.of("val1"),
+						new NumberedCustomField("f2"), OptionalString.of("val2"),
+						new NumberedCustomField("f3"), OptionalString.empty()),
 				new UnauthorizedException(
 						"User member is not authorized to set field f2 for group gid"));
 		
@@ -771,7 +757,7 @@ public class GroupsTest {
 			final Token t,
 			final GroupID gid,
 			final UserName target,
-			final Map<NumberedCustomField, StringField> fields,
+			final Map<NumberedCustomField, OptionalString> fields,
 			final Exception expected) {
 		try {
 			g.updateUser(t, gid, target, fields);

--- a/src/us/kbase/test/groups/core/OptionalGroupFieldsTest.java
+++ b/src/us/kbase/test/groups/core/OptionalGroupFieldsTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.groups.core.FieldItem;
 import us.kbase.groups.core.OptionalGroupFields;
+import us.kbase.groups.core.OptionalString;
 import us.kbase.groups.core.FieldItem.StringField;
 import us.kbase.groups.core.exceptions.IllegalParameterException;
 import us.kbase.groups.core.fieldvalidation.NumberedCustomField;
@@ -93,9 +94,9 @@ public class OptionalGroupFieldsTest {
 	public void buildMaximal() throws Exception {
 		final OptionalGroupFields ofg = OptionalGroupFields.getBuilder()
 				.withDescription(StringField.from("   foo    "))
-				.withCustomField(new NumberedCustomField("foo-1"), StringField.from("  val  "))
-				.withCustomField(new NumberedCustomField("foo"), StringField.remove())
-				.withCustomField(new NumberedCustomField("bar"), StringField.noAction())
+				.withCustomField(new NumberedCustomField("foo-1"), OptionalString.of("  val  "))
+				.withCustomField(new NumberedCustomField("foo"), OptionalString.empty())
+				.withCustomField(new NumberedCustomField("bar"), OptionalString.empty())
 				.build();
 		
 		assertThat("incorrect desc", ofg.getDescription(), is(FieldItem.from("foo")));
@@ -104,17 +105,17 @@ public class OptionalGroupFieldsTest {
 				set(new NumberedCustomField("foo-1"), new NumberedCustomField("foo"),
 						new NumberedCustomField("bar"))));
 		assertThat("incorrect val", ofg.getCustomValue(new NumberedCustomField("foo-1")),
-				is(StringField.from("val")));
+				is(OptionalString.of("val")));
 		assertThat("incorrect val", ofg.getCustomValue(new NumberedCustomField("foo")),
-				is(StringField.remove()));
+				is(OptionalString.empty()));
 		assertThat("incorrect val", ofg.getCustomValue(new NumberedCustomField("bar")),
-				is(StringField.noAction()));
+				is(OptionalString.empty()));
 	}
 	
 	@Test
 	public void buildWithCustomFieldWithUpdate() throws Exception {
 		final OptionalGroupFields ofg = OptionalGroupFields.getBuilder()
-				.withCustomField(new NumberedCustomField("bar"), StringField.remove())
+				.withCustomField(new NumberedCustomField("bar"), OptionalString.empty())
 				.build();
 		
 		assertThat("incorrect desc", ofg.getDescription(), is(FieldItem.noAction()));
@@ -122,32 +123,18 @@ public class OptionalGroupFieldsTest {
 		assertThat("incorrect fields", ofg.getCustomFields(), is(
 				set(new NumberedCustomField("bar"))));
 		assertThat("incorrect val", ofg.getCustomValue(new NumberedCustomField("bar")),
-				is(StringField.remove()));
+				is(OptionalString.empty()));
 	}
 	
 	@Test
-	public void buildWithCustomFieldNoUpdate() throws Exception {
-		final OptionalGroupFields ofg = OptionalGroupFields.getBuilder()
-				.withCustomField(new NumberedCustomField("bar"), StringField.noAction())
-				.build();
-		
-		assertThat("incorrect desc", ofg.getDescription(), is(FieldItem.noAction()));
-		assertThat("incorrect update", ofg.hasUpdate(), is(false));
-		assertThat("incorrect fields", ofg.getCustomFields(), is(
-				set(new NumberedCustomField("bar"))));
-		assertThat("incorrect val", ofg.getCustomValue(new NumberedCustomField("bar")),
-				is(StringField.noAction()));
-	}
-
-	@Test
 	public void withCustomFieldFail() throws Exception {
-		failWithCustomField(null, StringField.noAction(), new NullPointerException("field"));
+		failWithCustomField(null, OptionalString.empty(), new NullPointerException("field"));
 		failWithCustomField(new NumberedCustomField("a"), null, new NullPointerException("value"));
 	}
 	
 	private void failWithCustomField(
 			final NumberedCustomField field,
-			final StringField value,
+			final OptionalString value,
 			final Exception expected) {
 		try {
 			OptionalGroupFields.getBuilder().withCustomField(field, value);
@@ -160,7 +147,7 @@ public class OptionalGroupFieldsTest {
 	@Test
 	public void getCustomValueFail() throws Exception {
 		final OptionalGroupFields ofg = OptionalGroupFields.getBuilder()
-				.withCustomField(new NumberedCustomField("bar"), StringField.noAction())
+				.withCustomField(new NumberedCustomField("bar"), OptionalString.empty())
 				.build();
 
 		failGetCustomValue(ofg, null, new NullPointerException("field"));

--- a/src/us/kbase/test/groups/core/OptionalStringTest.java
+++ b/src/us/kbase/test/groups/core/OptionalStringTest.java
@@ -1,0 +1,93 @@
+package us.kbase.test.groups.core;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.groups.core.OptionalString;
+import us.kbase.test.groups.TestCommon;
+
+public class OptionalStringTest {
+
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(OptionalString.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void empty() throws Exception {
+		final OptionalString e = OptionalString.empty();
+		
+		assertThat("incorrect isPresent", e.isPresent(), is(false));
+		assertThat("incorrect isPresent", e.orNull(), is((String) null));
+		assertThat("incorrect isPresent", e.toString(), is("OptionalString.empty"));
+	}
+	
+	@Test
+	public void of() throws Exception {
+		final OptionalString e = OptionalString.of("     val   \t   ");
+		
+		assertThat("incorrect get", e.get(), is("val"));
+		assertThat("incorrect isPresent", e.isPresent(), is(true));
+		assertThat("incorrect isPresent", e.orNull(), is("val"));
+		assertThat("incorrect isPresent", e.toString(), is("OptionalString[val]"));
+	}
+
+	@Test
+	public void ofEmptyableWithNull() throws Exception {
+		final OptionalString e = OptionalString.ofEmptyable(null);
+		
+		assertThat("incorrect isPresent", e.isPresent(), is(false));
+		assertThat("incorrect isPresent", e.orNull(), is((String) null));
+		assertThat("incorrect isPresent", e.toString(), is("OptionalString.empty"));
+	}
+	
+	@Test
+	public void ofEmptyableWithWhitespace() throws Exception {
+		final OptionalString e = OptionalString.ofEmptyable("   \t     ");
+		
+		assertThat("incorrect isPresent", e.isPresent(), is(false));
+		assertThat("incorrect isPresent", e.orNull(), is((String) null));
+		assertThat("incorrect isPresent", e.toString(), is("OptionalString.empty"));
+	}
+	
+	@Test
+	public void ofEmptyableWithValue() throws Exception {
+		final OptionalString e = OptionalString.ofEmptyable("     val   \t   ");
+		
+		assertThat("incorrect get", e.get(), is("val"));
+		assertThat("incorrect isPresent", e.isPresent(), is(true));
+		assertThat("incorrect isPresent", e.orNull(), is("val"));
+		assertThat("incorrect isPresent", e.toString(), is("OptionalString[val]"));
+	}
+	
+	@Test
+	public void ofFail() throws Exception {
+		ofFail(null, new IllegalArgumentException("value cannot be null or whitespace only"));
+		ofFail("  \t ", new IllegalArgumentException("value cannot be null or whitespace only"));
+	}
+	
+	private void ofFail(final String value, final Exception expected) {
+		try {
+			OptionalString.of(value);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void getFail() throws Exception {
+		try {
+			OptionalString.empty().get();
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalStateException(
+					"Cannot call get() on an empty OptionalString"));
+		}
+	}
+
+}

--- a/src/us/kbase/test/groups/service/api/GroupsAPITest.java
+++ b/src/us/kbase/test/groups/service/api/GroupsAPITest.java
@@ -37,6 +37,7 @@ import us.kbase.groups.core.GroupUser;
 import us.kbase.groups.core.GroupView;
 import us.kbase.groups.core.Groups;
 import us.kbase.groups.core.OptionalGroupFields;
+import us.kbase.groups.core.OptionalString;
 import us.kbase.groups.core.Token;
 import us.kbase.groups.core.UserName;
 import us.kbase.groups.core.exceptions.ErrorType;
@@ -317,9 +318,9 @@ public class GroupsAPITest {
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("my desc"))
 						.withCustomField(new NumberedCustomField("foo-23"),
-								StringField.from("yay"))
+								OptionalString.of("yay"))
 						.withCustomField(new NumberedCustomField("doodybutt"),
-								StringField.from("yo"))
+								OptionalString.of("yo"))
 						.build())
 				.build()))
 				.thenReturn(GroupView.getBuilder(GROUP_MIN, new UserName("u"))
@@ -443,8 +444,8 @@ public class GroupsAPITest {
 				GroupUpdateParams.getBuilder(new GroupID("gid"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.remove())
-						.withCustomField(new NumberedCustomField("foo"), StringField.remove())
-						.withCustomField(new NumberedCustomField("bar"), StringField.remove())
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.empty())
+						.withCustomField(new NumberedCustomField("bar"), OptionalString.empty())
 						.build())
 				.build());
 	}
@@ -457,8 +458,8 @@ public class GroupsAPITest {
 				GroupUpdateParams.getBuilder(new GroupID("gid"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.remove())
-						.withCustomField(new NumberedCustomField("foo"), StringField.remove())
-						.withCustomField(new NumberedCustomField("bar"), StringField.remove())
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.empty())
+						.withCustomField(new NumberedCustomField("bar"), OptionalString.empty())
 						.build())
 				.build());
 	}
@@ -475,9 +476,9 @@ public class GroupsAPITest {
 						.withOptionalFields(OptionalGroupFields.getBuilder()
 								.withDescription(StringField.from("desc"))
 								.withCustomField(new NumberedCustomField("foo"),
-										StringField.from("baz"))
+										OptionalString.of("baz"))
 								.withCustomField(new NumberedCustomField("bar"),
-										StringField.from("bat"))
+										OptionalString.of("bat"))
 								.build())
 						.build());
 	}
@@ -1215,8 +1216,8 @@ public class GroupsAPITest {
 				new UpdateUserJSON(fields));
 		
 		verify(g).updateUser(new Token("   tok  "), new GroupID("gid"), new UserName("user"),
-				ImmutableMap.of(new NumberedCustomField("f1"), StringField.remove(),
-						new NumberedCustomField("f2"), StringField.remove()));
+				ImmutableMap.of(new NumberedCustomField("f1"), OptionalString.empty(),
+						new NumberedCustomField("f2"), OptionalString.empty()));
 	}
 
 	@Test
@@ -1232,8 +1233,8 @@ public class GroupsAPITest {
 				new UpdateUserJSON(fields));
 		
 		verify(g).updateUser(new Token("   tok  "), new GroupID("gid"), new UserName("user"),
-				ImmutableMap.of(new NumberedCustomField("f1"), StringField.remove(),
-						new NumberedCustomField("f2"), StringField.remove()));
+				ImmutableMap.of(new NumberedCustomField("f1"), OptionalString.empty(),
+						new NumberedCustomField("f2"), OptionalString.empty()));
 	}
 	
 	@Test
@@ -1249,8 +1250,8 @@ public class GroupsAPITest {
 				new UpdateUserJSON(fields));
 		
 		verify(g).updateUser(new Token("   tok  "), new GroupID("gid"), new UserName("user"),
-				ImmutableMap.of(new NumberedCustomField("f1"), StringField.from("val1"),
-						new NumberedCustomField("f2"), StringField.from("val2")));
+				ImmutableMap.of(new NumberedCustomField("f1"), OptionalString.of("val1"),
+						new NumberedCustomField("f2"), OptionalString.of("val2")));
 	}
 	
 	@Test
@@ -1322,7 +1323,7 @@ public class GroupsAPITest {
 		
 		doThrow(new NoSuchUserException("foo")).when(g).updateUser(
 				new Token("tok"), new GroupID("i"), new UserName("n"),
-				ImmutableMap.of(new NumberedCustomField("f"), StringField.remove()));
+				ImmutableMap.of(new NumberedCustomField("f"), OptionalString.empty()));
 
 		updateUserFail(g, "tok", "  i", "n", new UpdateUserJSON(ImmutableMap.of("f", "  ")),
 				new NoSuchUserException("foo"));

--- a/src/us/kbase/test/groups/storage/mongo/MongoGroupsStorageOpsTest.java
+++ b/src/us/kbase/test/groups/storage/mongo/MongoGroupsStorageOpsTest.java
@@ -38,6 +38,7 @@ import us.kbase.groups.core.GroupName;
 import us.kbase.groups.core.GroupUpdateParams;
 import us.kbase.groups.core.GroupUser;
 import us.kbase.groups.core.OptionalGroupFields;
+import us.kbase.groups.core.OptionalString;
 import us.kbase.groups.core.CreateAndModTimes;
 import us.kbase.groups.core.CreateModAndExpireTimes;
 import us.kbase.groups.core.GetRequestsParams;
@@ -339,7 +340,7 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateGroup(GroupUpdateParams.getBuilder(gid)
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withCustomField(new NumberedCustomField("foo-1"),
-								StringField.from("yay!"))
+								OptionalString.of("yay!"))
 						.build())
 				.build(),
 				inst(90000));
@@ -352,7 +353,7 @@ public class MongoGroupsStorageOpsTest {
 		
 		manager.storage.updateGroup(GroupUpdateParams.getBuilder(gid)
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withCustomField(new NumberedCustomField("foo-1"), StringField.remove())
+						.withCustomField(new NumberedCustomField("foo-1"), OptionalString.empty())
 						.build())
 				.build(),
 				inst(100000));
@@ -374,15 +375,13 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateGroup(GroupUpdateParams.getBuilder(gid)
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withCustomField(new NumberedCustomField("foo-1"),
-								StringField.from("valfoo"))
+								OptionalString.of("valfoo"))
 						.withCustomField(new NumberedCustomField("bar"),
-								StringField.remove())
-						.withCustomField(new NumberedCustomField("baz"),
-								StringField.noAction())
+								OptionalString.empty())
 						.withCustomField(new NumberedCustomField("foo-2"),
-								StringField.from("valfoo2"))
+								OptionalString.of("valfoo2"))
 						.withCustomField(new NumberedCustomField("foo-3"),
-								StringField.from("valfoo3"))
+								OptionalString.of("valfoo3"))
 						.build())
 				.build(),
 				inst(90000));
@@ -397,16 +396,10 @@ public class MongoGroupsStorageOpsTest {
 		
 		manager.storage.updateGroup(GroupUpdateParams.getBuilder(gid)
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withCustomField(new NumberedCustomField("foo-1"),
-								StringField.remove())
+						.withCustomField(new NumberedCustomField("foo-1"), OptionalString.empty())
 						.withCustomField(new NumberedCustomField("foo-3"),
-								StringField.from("valfoo42"))
-						.withCustomField(new NumberedCustomField("bar"),
-								StringField.remove())
-						.withCustomField(new NumberedCustomField("baz"),
-								StringField.noAction())
-						.withCustomField(new NumberedCustomField("foo-2"),
-								StringField.noAction())
+								OptionalString.of("valfoo42"))
+						.withCustomField(new NumberedCustomField("bar"), OptionalString.empty())
 						.build())
 				.build(),
 				inst(100000));
@@ -434,8 +427,9 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("newname"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("other desc"))
-						.withCustomField(new NumberedCustomField("foo-2"), StringField.remove())
-						.withCustomField(new NumberedCustomField("foo-3"), StringField.from("meh"))
+						.withCustomField(new NumberedCustomField("foo-2"), OptionalString.empty())
+						.withCustomField(new NumberedCustomField("foo-3"),
+								OptionalString.of("meh"))
 						.build())
 				.build(),
 				inst(30001));
@@ -450,15 +444,18 @@ public class MongoGroupsStorageOpsTest {
 	
 	@Test
 	public void updateGroupNoopMinimalNoAction() throws Exception {
-		updateGroupNoopMinimal(StringField.noAction());
+		updateGroupNoopMinimal(StringField.noAction(), OptionalString.empty());
 	}
 	
 	@Test
 	public void updateGroupNoopMinimalRemove() throws Exception {
-		updateGroupNoopMinimal(StringField.remove());
+		updateGroupNoopMinimal(StringField.remove(), OptionalString.empty());
 	}
 
-	private void updateGroupNoopMinimal(final StringField action) throws Exception {
+	private void updateGroupNoopMinimal(
+			final StringField descAction,
+			final OptionalString cfAction)
+			throws Exception {
 		// tests updating a group with identical contents. Ensure the mod date isn't set.
 		final GroupID gid = new GroupID("gid");
 		manager.storage.createGroup(Group.getBuilder(
@@ -469,8 +466,8 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateGroup(GroupUpdateParams.getBuilder(gid)
 				.withName(new GroupName("name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
-						.withDescription(action)
-						.withCustomField(new NumberedCustomField("yay"), action)
+						.withDescription(descAction)
+						.withCustomField(new NumberedCustomField("yay"), cfAction)
 						.build())
 				.build(),
 				inst(50000));
@@ -498,9 +495,9 @@ public class MongoGroupsStorageOpsTest {
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("my desc"))
 						.withCustomField(new NumberedCustomField("thatlast"),
-								StringField.from("test was a bit rude"))
+								OptionalString.of("test was a bit rude"))
 						.withCustomField(new NumberedCustomField("yesi-1"),
-								StringField.from("agree it was a bit"))
+								OptionalString.of("agree it was a bit"))
 						.build())
 				.build(),
 				inst(50000));
@@ -529,7 +526,7 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.remove())
-						.withCustomField(new NumberedCustomField("foo"), StringField.from("bar"))
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.of("bar"))
 						.build())
 				.build(),
 				inst(50000));
@@ -545,7 +542,7 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.remove())
-						.withCustomField(new NumberedCustomField("foo"), StringField.from("bar"))
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.of("bar"))
 						.build())
 				.build(),
 				inst(760000));
@@ -561,7 +558,7 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("new name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.noAction())
-						.withCustomField(new NumberedCustomField("foo"), StringField.from("bar"))
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.of("bar"))
 						.build())
 				.build(),
 				inst(60000));
@@ -577,7 +574,7 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("new name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("yay!"))
-						.withCustomField(new NumberedCustomField("foo"), StringField.from("bar"))
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.of("bar"))
 						.build())
 				.build(),
 				inst(80000));
@@ -594,8 +591,8 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("new name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("yay!"))
-						.withCustomField(new NumberedCustomField("foo"), StringField.from("bar"))
-						.withCustomField(new NumberedCustomField("baz"), StringField.from("bat"))
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.of("bar"))
+						.withCustomField(new NumberedCustomField("baz"), OptionalString.of("bat"))
 						.build())
 				.build(),
 				inst(100000));
@@ -613,8 +610,8 @@ public class MongoGroupsStorageOpsTest {
 				.withName(new GroupName("new name"))
 				.withOptionalFields(OptionalGroupFields.getBuilder()
 						.withDescription(StringField.from("yay!"))
-						.withCustomField(new NumberedCustomField("foo"), StringField.remove())
-						.withCustomField(new NumberedCustomField("baz"), StringField.from("bat"))
+						.withCustomField(new NumberedCustomField("foo"), OptionalString.empty())
+						.withCustomField(new NumberedCustomField("baz"), OptionalString.of("bat"))
 						.build())
 				.build(),
 				inst(100000));
@@ -1277,7 +1274,7 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateUser(
 				new GroupID("gid"),
 				new UserName("admin"),
-				ImmutableMap.of(new NumberedCustomField("f1-3"), StringField.from("val")),
+				ImmutableMap.of(new NumberedCustomField("f1-3"), OptionalString.of("val")),
 				inst(75000));
 		
 		assertThat("incorrect update", manager.storage.getGroup(new GroupID("gid")),
@@ -1294,7 +1291,7 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateUser(
 				new GroupID("gid"),
 				new UserName("admin"),
-				ImmutableMap.of(new NumberedCustomField("f1-3"), StringField.from("val")),
+				ImmutableMap.of(new NumberedCustomField("f1-3"), OptionalString.of("val")),
 				inst(80000));
 		
 		assertThat("incorrect update", manager.storage.getGroup(new GroupID("gid")),
@@ -1310,7 +1307,7 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateUser(
 				new GroupID("gid"),
 				new UserName("admin"),
-				ImmutableMap.of(new NumberedCustomField("f1-3"), StringField.remove()),
+				ImmutableMap.of(new NumberedCustomField("f1-3"), OptionalString.empty()),
 				inst(80000));
 		
 		assertThat("incorrect update", manager.storage.getGroup(new GroupID("gid")),
@@ -1326,7 +1323,7 @@ public class MongoGroupsStorageOpsTest {
 		manager.storage.updateUser(
 				new GroupID("gid"),
 				new UserName("admin"),
-				ImmutableMap.of(new NumberedCustomField("f1-3"), StringField.remove()),
+				ImmutableMap.of(new NumberedCustomField("f1-3"), OptionalString.empty()),
 				inst(90000));
 		
 		assertThat("incorrect update", manager.storage.getGroup(new GroupID("gid")),
@@ -1394,11 +1391,10 @@ public class MongoGroupsStorageOpsTest {
 				new GroupID("gid"),
 				new UserName("member"),
 				ImmutableMap.of(
-						new NumberedCustomField("foo-1"), StringField.from("valfoo"),
-						new NumberedCustomField("bar"), StringField.remove(),
-						new NumberedCustomField("baz"), StringField.noAction(),
-						new NumberedCustomField("foo-2"), StringField.from("valfoo2"),
-						new NumberedCustomField("foo-3"), StringField.from("valfoo3")),
+						new NumberedCustomField("foo-1"), OptionalString.of("valfoo"),
+						new NumberedCustomField("bar"), OptionalString.empty(),
+						new NumberedCustomField("foo-2"), OptionalString.of("valfoo2"),
+						new NumberedCustomField("foo-3"), OptionalString.of("valfoo3")),
 				inst(70000));
 		
 		assertThat("incorrect group", manager.storage.getGroup(new GroupID("gid")),
@@ -1416,11 +1412,9 @@ public class MongoGroupsStorageOpsTest {
 				new GroupID("gid"),
 				new UserName("member"),
 				ImmutableMap.of(
-						new NumberedCustomField("foo-1"), StringField.remove(),
-						new NumberedCustomField("foo-3"), StringField.from("valfoo42"),
-						new NumberedCustomField("bar"), StringField.remove(),
-						new NumberedCustomField("baz"), StringField.noAction(),
-						new NumberedCustomField("foo-2"), StringField.noAction()),
+						new NumberedCustomField("foo-1"), OptionalString.empty(),
+						new NumberedCustomField("foo-3"), OptionalString.of("valfoo42"),
+						new NumberedCustomField("bar"), OptionalString.empty()),
 				inst(90000));
 		
 		assertThat("incorrect group", manager.storage.getGroup(new GroupID("gid")),
@@ -1448,37 +1442,6 @@ public class MongoGroupsStorageOpsTest {
 				is(getUOFGroup()));
 	}
 	
-	// this is a good example of why NoAction isn't needed here
-	@Test
-	public void updateFieldsNoopNoAction() throws Exception {
-		manager.storage.createGroup(getUOFGroup());
-		
-		manager.storage.updateUser(
-				new GroupID("gid"),
-				new UserName("admin"),
-				ImmutableMap.of(new NumberedCustomField("f-1"), StringField.noAction(),
-						new NumberedCustomField("f2"), StringField.noAction()),
-				inst(60000));
-		
-		assertThat("noop update failed", manager.storage.getGroup(new GroupID("gid")),
-				is(getUOFGroup()));
-	}
-	
-	@Test
-	public void updateFieldsNoopNoChangeFromUpdateNoAction() throws Exception {
-		manager.storage.createGroup(getUOFGroup());
-		
-		manager.storage.updateUser(
-				new GroupID("gid"),
-				new UserName("admin"),
-				ImmutableMap.of(
-						new NumberedCustomField("fieldtwo"), StringField.noAction()),
-				inst(60000));
-		
-		assertThat("noop update failed", manager.storage.getGroup(new GroupID("gid")),
-				is(getUOFGroup()));
-	}
-	
 	@Test
 	public void updateFieldsNoopNoChangeFromUpdateRemove() throws Exception {
 		manager.storage.createGroup(getUOFGroup());
@@ -1487,7 +1450,7 @@ public class MongoGroupsStorageOpsTest {
 				new GroupID("gid"),
 				new UserName("admin"),
 				ImmutableMap.of(
-						new NumberedCustomField("nosuchfield"), StringField.remove()),
+						new NumberedCustomField("nosuchfield"), OptionalString.empty()),
 				inst(60000));
 		
 		assertThat("noop update failed", manager.storage.getGroup(new GroupID("gid")),
@@ -1502,7 +1465,7 @@ public class MongoGroupsStorageOpsTest {
 				new GroupID("gid"),
 				new UserName("admin"),
 				ImmutableMap.of(
-						new NumberedCustomField("fieldtwo"), StringField.from("keep")),
+						new NumberedCustomField("fieldtwo"), OptionalString.of("keep")),
 				inst(60000));
 		
 		assertThat("noop update failed", manager.storage.getGroup(new GroupID("gid")),
@@ -1517,10 +1480,8 @@ public class MongoGroupsStorageOpsTest {
 				new GroupID("gid"),
 				new UserName("admin"),
 				ImmutableMap.of(
-						new NumberedCustomField("newfield"), StringField.remove(),
-						new NumberedCustomField("newfield2"), StringField.noAction(),
-						new NumberedCustomField("fieldthree-22"), StringField.from("alter"),
-						new NumberedCustomField("fieldtwo"), StringField.noAction()),
+						new NumberedCustomField("newfield"), OptionalString.empty(),
+						new NumberedCustomField("fieldthree-22"), OptionalString.of("alter")),
 				inst(60000));
 		
 		assertThat("noop update failed", manager.storage.getGroup(new GroupID("gid")),
@@ -1534,10 +1495,9 @@ public class MongoGroupsStorageOpsTest {
 				new GroupID("gid"),
 				toUpdate,
 				ImmutableMap.of(
-						new NumberedCustomField("newfield"), StringField.from("new"),
-						new NumberedCustomField("field-1"), StringField.remove(),
-						new NumberedCustomField("fieldthree-22"), StringField.from("done"),
-						new NumberedCustomField("fieldtwo"), StringField.noAction()),
+						new NumberedCustomField("newfield"), OptionalString.of("new"),
+						new NumberedCustomField("field-1"), OptionalString.empty(),
+						new NumberedCustomField("fieldthree-22"), OptionalString.of("done")),
 				inst(60000));
 	}
 
@@ -1573,7 +1533,7 @@ public class MongoGroupsStorageOpsTest {
 	public void updateUserFailNulls() throws Exception {
 		final GroupID g = new GroupID("g");
 		final UserName n = new UserName("n");
-		final Map<NumberedCustomField, StringField> f = new HashMap<>();
+		final Map<NumberedCustomField, OptionalString> f = new HashMap<>();
 		final Instant i = inst(1);
 		
 		updateUserFail(null, n, f, i, new NullPointerException("groupID"));
@@ -1581,7 +1541,7 @@ public class MongoGroupsStorageOpsTest {
 		updateUserFail(g, n, null, i, new NullPointerException("fields"));
 		updateUserFail(g, n, f, null, new NullPointerException("modDate"));
 		
-		f.put(null, StringField.remove());
+		f.put(null, OptionalString.empty());
 		updateUserFail(g, n, f, i, new NullPointerException("Null key in fields"));
 		
 		f.clear();
@@ -1602,7 +1562,7 @@ public class MongoGroupsStorageOpsTest {
 		updateUserFail(
 				new GroupID("gid1"),
 				new UserName("m"),
-				ImmutableMap.of(new NumberedCustomField("f"), StringField.remove()),
+				ImmutableMap.of(new NumberedCustomField("f"), OptionalString.empty()),
 				inst(40000),
 				new NoSuchGroupException("gid1"));
 	}
@@ -1620,7 +1580,7 @@ public class MongoGroupsStorageOpsTest {
 		updateUserFail(
 				new GroupID("gid"),
 				new UserName("m1"),
-				ImmutableMap.of(new NumberedCustomField("f"), StringField.remove()),
+				ImmutableMap.of(new NumberedCustomField("f"), OptionalString.empty()),
 				inst(40000),
 				new NoSuchUserException("User m1 is not a member of group gid"));
 	}
@@ -1628,7 +1588,7 @@ public class MongoGroupsStorageOpsTest {
 	private void updateUserFail(
 			final GroupID gid,
 			final UserName name,
-			final Map<NumberedCustomField, StringField> fields,
+			final Map<NumberedCustomField, OptionalString> fields,
 			final Instant modDate,
 			final Exception expected) {
 		try {


### PR DESCRIPTION
No action can be represented by just leaving the field out of the map.
No need for a set / remove / no action class like for the standard
fields.