### PR TITLE
SCT-1486 Fix missing field validator on get group(s) bug

### DIFF
--- a/src/us/kbase/groups/core/GroupView.java
+++ b/src/us/kbase/groups/core/GroupView.java
@@ -456,6 +456,7 @@ public class GroupView {
 			return this;
 		}
 		
+		//TODO NNOW use these next 2 in groups
 		/** Add a function that will be used to determine which user fields are public fields and
 		 * therefore viewable by all users, not just group members.
 		 * By default, no fields are considered to be public fields.

--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -247,7 +247,7 @@ public class Groups {
 		validateUserCustomFields(fields);
 		if (!g.isAdministrator(user)) {
 			for (final NumberedCustomField f: fields.keySet()) {
-				if (!validators.getUserFieldConfiguration(f.getFieldRoot()).isUserSettable()) {
+				if (!validators.getUserFieldConfig(f.getFieldRoot()).isUserSettable()) {
 					throw new UnauthorizedException(String.format(
 							"User %s is not authorized to set field %s for group %s",
 							user.getName(), f.getField(), groupID.getName()));
@@ -329,7 +329,8 @@ public class Groups {
 		final UserName user = getOptionalUser(userToken);
 		final GroupView.Builder b = startViewBuild(g, user)
 				.withPublicFieldDeterminer(
-						f -> validators.getConfiguration(f.getFieldRoot()).isPublicField());
+						f -> validators.getConfigOrEmpty(f.getFieldRoot())
+								.map(c -> c.isPublicField()).orElse(false));
 		for (final ResourceType type: g.getResourceTypes()) {
 			processGroupType(g, user, type, b);
 		}
@@ -412,11 +413,11 @@ public class Groups {
 		return storage.getGroups(params, user).stream()
 				.map(g -> GroupView.getBuilder(g, user)
 						.withMinimalViewFieldDeterminer(
-								f -> validators.getConfiguration(f.getFieldRoot())
-										.isMinimalViewField())
+								f -> validators.getConfigOrEmpty(f.getFieldRoot())
+										.map(c -> c.isMinimalViewField()).orElse(false))
 						.withPublicFieldDeterminer(
-								f -> validators.getConfiguration(f.getFieldRoot())
-										.isPublicField())
+								f -> validators.getConfigOrEmpty(f.getFieldRoot())
+										.map(c -> c.isPublicField()).orElse(false))
 						.build())
 				.collect(Collectors.toList());
 	}

--- a/src/us/kbase/groups/core/fieldvalidation/FieldValidators.java
+++ b/src/us/kbase/groups/core/fieldvalidation/FieldValidators.java
@@ -6,6 +6,7 @@ import static us.kbase.groups.util.Util.checkString;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import us.kbase.groups.core.exceptions.IllegalParameterException;
@@ -123,29 +124,53 @@ public class FieldValidators {
 	
 	/** Get the configuration for a field.
 	 * @param field the field to check.
+	 * @throws IllegalArgumentException if the field does not exist.
 	 * @return the configuration.
 	 */
-	public FieldConfiguration getConfiguration(final CustomField field) {
-		return getConfiguration(field, validators, fieldConfig);
+	public FieldConfiguration getConfig(final CustomField field) {
+		return getConfigOrThrow(field, validators, fieldConfig);
 	}
 	
 	/** Get the configuration for a user field.
 	 * @param field the field to check.
+	 * @throws IllegalArgumentException if the field does not exist.
 	 * @return the configuration.
 	 */
-	public FieldConfiguration getUserFieldConfiguration(final CustomField field) {
-		return getConfiguration(field, userValidators, userFieldConfig);
+	public FieldConfiguration getUserFieldConfig(final CustomField field) {
+		return getConfigOrThrow(field, userValidators, userFieldConfig);
+	}
+	
+	/** Get the configuration for a field, or {@link Optional#empty()} if the field does not exist.
+	 * @param field the field to check.
+	 * @return the configuration.
+	 */
+	public Optional<FieldConfiguration> getConfigOrEmpty(final CustomField field) {
+		return getConfig(field, validators, fieldConfig);
+	}
+	
+	/** Get the configuration for a user field, or {@link Optional#empty()} if the field does
+	 * not exist.
+	 * @param field the field to check.
+	 * @return the configuration.
+	 */
+	public Optional<FieldConfiguration> getUserFieldConfigOrEmpty(final CustomField field) {
+		return getConfig(field, userValidators, userFieldConfig);
 	}
 
-	private FieldConfiguration getConfiguration(
+	private Optional<FieldConfiguration> getConfig(
 			final CustomField field,
 			final Map<CustomField, FieldValidator> validators,
 			final Map<CustomField, FieldConfiguration> fieldConfig) {
 		checkNotNull(field, "field");
-		if (!validators.containsKey(field)) {
-			throw new IllegalArgumentException("No such custom field: " + field.getName());
-		}
-		return fieldConfig.get(field);
+		return Optional.ofNullable(fieldConfig.get(field));
+	}
+	
+	private FieldConfiguration getConfigOrThrow(
+			final CustomField field,
+			final Map<CustomField, FieldValidator> validators,
+			final Map<CustomField, FieldConfiguration> fieldConfig) {
+		return getConfig(field, validators, fieldConfig).orElseThrow(
+				() -> new IllegalArgumentException("No such custom field: " + field.getName()));
 	}
 	
 	/** Get a builder for a {@link FieldValidators}.


### PR DESCRIPTION
Currently will throw an error if a group is fetched that contains a
custom field where the validator has been removed from the config. Now
fields without validators are treated as though they're private and
don't show up in the list view, but never throw errors.