### PR TITLE
SCT-1486 Revert group list view owner field to owner name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Represents a group of users and associated data.
     "private": <true if the group is private, false otherwise>,
     "ismember": <true if the user accessing the group is a member, false otherwise>,
     "name": <the group name>,
-    "owner": <the User data for the group owner>,
+    "owner": <the User data or user name for the group owner>,
     "admins": <an array of User data of admins of the group>,
     "members": <an array of User data of members of the group>,
     "createdate": <the group creation date in epoch ms>,
@@ -53,6 +53,9 @@ Represents a group of users and associated data.
     }
 }
 ```
+
+In a full view of the group, the owner field contains a `User` structure. In a group list view,
+the owner field contains only the user name of the owner.
 
 See `Resources` and `Custom fields` below.
 
@@ -209,6 +212,9 @@ RETURNS:
 A list of Groups. Only the id, name, owner, custom, createdate, and moddate fields
 are included.
 ```
+
+The owner field consists only of the user name for this endpoint. For all other endpoints,
+the owner field is a full `User` data structure.
 
 A maximum of 100 groups are returned.
 

--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -430,9 +430,6 @@ public class Groups {
 						.withPublicFieldDeterminer(
 								f -> validators.getConfigOrEmpty(f.getFieldRoot())
 										.map(c -> c.isPublicField()).orElse(false))
-						.withPublicUserFieldDeterminer(
-								f -> validators.getUserFieldConfigOrEmpty(f.getFieldRoot())
-										.map(c -> c.isPublicField()).orElse(false))
 						.build())
 				.collect(Collectors.toList());
 	}

--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -430,9 +430,6 @@ public class Groups {
 						.withPublicFieldDeterminer(
 								f -> validators.getConfigOrEmpty(f.getFieldRoot())
 										.map(c -> c.isPublicField()).orElse(false))
-						.withMinimalViewUserFieldDeterminer(
-								f -> validators.getUserFieldConfigOrEmpty(f.getFieldRoot())
-										.map(c -> c.isMinimalViewField()).orElse(false))
 						.withPublicUserFieldDeterminer(
 								f -> validators.getUserFieldConfigOrEmpty(f.getFieldRoot())
 										.map(c -> c.isPublicField()).orElse(false))

--- a/src/us/kbase/groups/service/api/GroupsAPI.java
+++ b/src/us/kbase/groups/service/api/GroupsAPI.java
@@ -303,11 +303,12 @@ public class GroupsAPI {
 		ret.put(Fields.GROUP_IS_MEMBER, g.isMember());
 		if (!g.isPrivateView()) {
 			ret.put(Fields.GROUP_NAME, g.getGroupName().get().getName());
-			ret.put(Fields.GROUP_OWNER, toUserJson(g.getMember(g.getOwner().get())));
+			ret.put(Fields.GROUP_OWNER, g.getOwner().get().getName());
 			ret.put(Fields.GROUP_CUSTOM_FIELDS, getCustomFields(g.getCustomFields()));
 			ret.put(Fields.GROUP_CREATION, g.getCreationDate().get().toEpochMilli());
 			ret.put(Fields.GROUP_MODIFICATION, g.getModificationDate().get().toEpochMilli());
 			if (g.isStandardView()) {
+				ret.put(Fields.GROUP_OWNER, toUserJson(g.getMember(g.getOwner().get())));
 				ret.put(Fields.GROUP_MEMBERS, toMemberList(g.getMembers(), g));
 				ret.put(Fields.GROUP_ADMINS, toMemberList(g.getAdministrators(), g));
 				final Map<String, Object> resources = new HashMap<>();

--- a/src/us/kbase/test/groups/core/GroupViewTest.java
+++ b/src/us/kbase/test/groups/core/GroupViewTest.java
@@ -102,9 +102,8 @@ public class GroupViewTest {
 		assertThat("incorrect view type", gv.isMember(), is(false));
 		assertThat("incorrect types", gv.getResourceTypes(), is(set()));
 		assertThat("incorrect custom", gv.getCustomFields(), is(Collections.emptyMap()));
-		assertThat("incorrect user", gv.getMember(new UserName("user")),
-				is(GroupUser.getBuilder(new UserName("user"), inst(10000)).build()));
 		
+		getMemberFail(gv, new UserName("user"));
 		getMemberFail(gv, new UserName("a1"));
 		getMemberFail(gv, new UserName("a2"));
 		getMemberFail(gv, new UserName("m1"));
@@ -333,7 +332,6 @@ public class GroupViewTest {
 	@Test
 	public void customFieldVisibility() throws Exception {
 		GroupView gv = GroupView.getBuilder(GROUP, null)
-				.withMinimalViewUserFieldDeterminer(f -> true)
 				.withPublicUserFieldDeterminer(f -> true)
 				.build();
 		assertThat("incorrect field", gv.getCustomFields(), is(Collections.emptyMap()));
@@ -405,36 +403,14 @@ public class GroupViewTest {
 				.withPublicFieldDeterminer(f -> true)
 				.withMinimalViewFieldDeterminer(f -> true)
 				.build();
-		assertThat("incorrect user fields", gv.getMember(owner),
-				is(GroupUser.getBuilder(owner, inst(1)).build()));
+		getMemberFail(gv, owner);
 		getMemberFail(gv, admin);
 		getMemberFail(gv, member);
 		
 		gv = GroupView.getBuilder(g, null)
-				.withMinimalViewUserFieldDeterminer(f -> f.getField().equals("field"))
-				.build();
-		assertThat("incorrect user fields", gv.getMember(owner),
-				is(GroupUser.getBuilder(owner, inst(1)).build()));
-		getMemberFail(gv, admin);
-		getMemberFail(gv, member);
-
-		gv = GroupView.getBuilder(g, null)
-				.withMinimalViewUserFieldDeterminer(f -> f.getField().equals("field"))
 				.withPublicUserFieldDeterminer(f -> f.getField().equals("field2"))
 				.build();
-		assertThat("incorrect user fields", gv.getMember(owner),
-				is(GroupUser.getBuilder(owner, inst(1)).build()));
-		getMemberFail(gv, admin);
-		getMemberFail(gv, member);
-
-		gv = GroupView.getBuilder(g, null)
-				.withMinimalViewUserFieldDeterminer(f -> f.getField().equals("field"))
-				.withPublicUserFieldDeterminer(f -> f.getField().equals("field"))
-				.build();
-		assertThat("incorrect user fields", gv.getMember(owner),
-				is(GroupUser.getBuilder(owner, inst(1))
-						.withCustomField(new NumberedCustomField("field"), "val")
-						.build()));
+		getMemberFail(gv, owner);
 		getMemberFail(gv, admin);
 		getMemberFail(gv, member);
 
@@ -454,18 +430,13 @@ public class GroupViewTest {
 
 		gv = GroupView.getBuilder(g, new UserName("m"))
 				.build();
-		assertThat("incorrect user fields", gv.getMember(owner),
-				is(GroupUser.getBuilder(owner, inst(1)).build()));
+		getMemberFail(gv, owner);
 		getMemberFail(gv, admin);
 		getMemberFail(gv, member);
 
 		gv = GroupView.getBuilder(g, new UserName("o"))
-				.withMinimalViewUserFieldDeterminer(f -> f.getField().equals("field"))
 				.build();
-		assertThat("incorrect user fields", gv.getMember(owner),
-				is(GroupUser.getBuilder(owner, inst(1))
-						.withCustomField(new NumberedCustomField("field"), "val")
-						.build()));
+		getMemberFail(gv, owner);
 		getMemberFail(gv, admin);
 		getMemberFail(gv, member);
 		
@@ -566,16 +537,6 @@ public class GroupViewTest {
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new NullPointerException("isPublic"));
-		}
-	}
-	
-	@Test
-	public void withMinimalViewUserFieldDeterminerFail() throws Exception {
-		try {
-			GroupView.getBuilder(GROUP, null).withMinimalViewUserFieldDeterminer(null);
-			fail("expected exception");
-		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new NullPointerException("isMinimalView"));
 		}
 	}
 	

--- a/src/us/kbase/test/groups/core/GroupsTest.java
+++ b/src/us/kbase/test/groups/core/GroupsTest.java
@@ -1242,6 +1242,7 @@ public class GroupsTest {
 	@Test
 	public void getGroupsWithCustomFields() throws Exception {
 		// tests that the custom fields are displayed correctly
+		// note user custom fields are never displayed in list view
 		final TestMocks mocks = initTestMocks();
 		
 		final GetGroupsParams mtparams = GetGroupsParams.getBuilder().build();
@@ -1310,7 +1311,6 @@ public class GroupsTest {
 				is(Arrays.asList(GroupView.getBuilder(Group.getBuilder(
 						new GroupID("id1"), new GroupName("name1"),
 						GroupUser.getBuilder(new UserName("o1"), inst(10000))
-								.withCustomField(new NumberedCustomField("minpub-6"), "uminpub")
 								.build(),
 						new CreateAndModTimes(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)))
@@ -1322,7 +1322,6 @@ public class GroupsTest {
 						null)
 						.withMinimalViewFieldDeterminer(f -> true)
 						.withPublicFieldDeterminer(f -> true)
-						.withMinimalViewUserFieldDeterminer(f -> true)
 						.withPublicUserFieldDeterminer(f -> true)
 						.build())));
 		
@@ -1331,7 +1330,6 @@ public class GroupsTest {
 				is(Arrays.asList(GroupView.getBuilder(Group.getBuilder(
 						new GroupID("id1"), new GroupName("name1"),
 						GroupUser.getBuilder(new UserName("o1"), inst(10000))
-								.withCustomField(new NumberedCustomField("minpub-6"), "uminpub")
 								.build(),
 						new CreateAndModTimes(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)))
@@ -1343,7 +1341,6 @@ public class GroupsTest {
 						new UserName("m2"))
 						.withMinimalViewFieldDeterminer(f -> true)
 						.withPublicFieldDeterminer(f -> true)
-						.withMinimalViewUserFieldDeterminer(f -> true)
 						.withPublicUserFieldDeterminer(f -> true)
 						.build())));
 		
@@ -1352,10 +1349,6 @@ public class GroupsTest {
 				is(Arrays.asList(GroupView.getBuilder(Group.getBuilder(
 						new GroupID("id1"), new GroupName("name1"),
 						GroupUser.getBuilder(new UserName("o1"), inst(10000))
-								.withCustomField(new NumberedCustomField("minpub-6"), "uminpub")
-								.withCustomField(new NumberedCustomField("minpriv-7"), "uminpriv")
-								.withCustomField(new NumberedCustomField("missingpub"),
-										"umissingonpub")
 								.build(),
 						new CreateAndModTimes(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)))
@@ -1369,7 +1362,6 @@ public class GroupsTest {
 						new UserName("m1"))
 						.withMinimalViewFieldDeterminer(f -> true)
 						.withPublicFieldDeterminer(f -> true)
-						.withMinimalViewUserFieldDeterminer(f -> true)
 						.withPublicUserFieldDeterminer(f -> true)
 						.build())));
 	}

--- a/src/us/kbase/test/groups/service/api/GroupsAPITest.java
+++ b/src/us/kbase/test/groups/service/api/GroupsAPITest.java
@@ -131,10 +131,7 @@ public class GroupsAPITest {
 			.with("private", false)
 			.with("ismember", false)
 			.with("name", "name")
-			.with("owner", ImmutableMap.of(
-					"name", "u",
-					"joined", 10000L,
-					"custom", ImmutableMap.of("something", "nothing")))
+			.with("owner", "u")
 			.with("createdate", 10000L)
 			.with("moddate", 10000L)
 			.with("custom", Collections.emptyMap())
@@ -211,10 +208,7 @@ public class GroupsAPITest {
 			.with("private", false)
 			.with("ismember", true)
 			.with("name", "name2")
-			.with("owner", ImmutableMap.of(
-					"name", "u2",
-					"joined", 20000L,
-					"custom", Collections.emptyMap()))
+			.with("owner", "u2")
 			.with("createdate", 20000L)
 			.with("moddate", 30000L)
 			.with("custom", ImmutableMap.of("field-1", "my val"))
@@ -264,7 +258,6 @@ public class GroupsAPITest {
 						.withMinimalViewFieldDeterminer(f -> f.getField().equals("field-1"))
 						.build(),
 				GroupView.getBuilder(GROUP_MIN, new UserName("u2"))
-						.withMinimalViewUserFieldDeterminer(f -> f.getField().equals("something"))
 						.withPublicUserFieldDeterminer(f -> f.getField().equals("something"))
 						.build()));
 		final List<Map<String, Object>> ret = new GroupsAPI(g)

--- a/testui/js/Groups.js
+++ b/testui/js/Groups.js
@@ -277,7 +277,7 @@ export default class {
                           <tr id="${s(g.id)}">
                             <th>${this.getGravatar(g)}${s(g.id)}</th>
                             <td>${s(g.name)}</td>
-                            <td>${s(g.owner.name)}</td>
+                            <td>${s(g.owner)}</td>
                             <td>${s(c)}</td>
                             <td>${s(m)}</td>
                           </tr>


### PR DESCRIPTION
Was a data structure including the user fields and join date, but that
means in order to get that data & the member count the entire member
array has to be fetched from mongo. This precludes various optimizations
to return info that's not necessary in the list view, so reverting to
just the name to allow for mongo projection optimizations in the future.