### PR TITLE
SCT-1486 Add MD5 check & optional max length check to gravatar validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,8 +730,17 @@ field-feast-param-allowed-values=lambs, sloths, carp, orangutans, breakfast cere
 
 #### us.kbase.groups.fieldvalidators.GravatarFieldValidatorFactory
 
-Checks that the value is a valid [Gravatar hash](https://en.gravatar.com/site/implement/hash/).
-Has no parameters.
+Checks that the value is a valid [Gravatar hash](https://en.gravatar.com/site/implement/hash/),
+meaning that the first 32 characters of the string constitute a valid MD5.
+
+Parameters (all optional):
+```
+field-<field name>-param-strict-length=<'true' or any other value for false>
+```
+
+`strict-length` will cause the validator to throw an error if the field is not exactly 32
+characters, and is false by default. Gravatar allows for extra characters at the end of the hash.
+
 
 ## Implementation notes
 

--- a/src/us/kbase/groups/fieldvalidators/GravatarFieldValidatorFactory.java
+++ b/src/us/kbase/groups/fieldvalidators/GravatarFieldValidatorFactory.java
@@ -1,7 +1,11 @@
 package us.kbase.groups.fieldvalidators;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.URI;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -16,34 +20,64 @@ import us.kbase.groups.core.fieldvalidation.FieldValidatorException;
 import us.kbase.groups.core.fieldvalidation.FieldValidatorFactory;
 import us.kbase.groups.core.fieldvalidation.IllegalFieldValueException;
 
-/** Validates that a gravatar hash is valid and does not return a 404.
+/** Validates that a gravatar hash is a valid MD5 and does not return a 404.
+ * Include "strict-length": "true" in the configuration to enforce an exact 32 character MD5.
+ * If omitted, any extra characters are ignored (which is what Gravatar does).
  * @author gaprice@lbl.gov
  *
  */
 public class GravatarFieldValidatorFactory implements FieldValidatorFactory {
 
+	private static final String TRUE = "true";
+	private static final String STRICT_LENGTH = "strict-length";
+	
 	@Override
 	public FieldValidator getValidator(final Map<String, String> configuration)
 			throws IllegalParameterException {
-		return new GravatarFieldValidator(404);
+		requireNonNull(configuration, "configuration");
+		return new GravatarFieldValidator(TRUE.equals(configuration.get(STRICT_LENGTH)), 404);
 	}
 	
 	private static class GravatarFieldValidator implements FieldValidator {
 		
-		private final int errorCode;
-		
-		// this constructor is here solely to allow testing the final exception
-		private GravatarFieldValidator(final int errorCode) {
-			this.errorCode = errorCode;
-		}
-		
 		private static final Client CLI = ClientBuilder.newClient();
 		private static final String GURL = "https://www.gravatar.com/";
 		private static final String GPATH = "avatar/";
+		private static final int MD5LEN = 32;
+		private static Pattern MD5CHARS = Pattern.compile("^[a-f0-9]+$");
+
+		private final boolean strictLength;
+		private final int errorCode;
+		
+		private GravatarFieldValidator(
+				final boolean strictLength,
+				final int errorCode) { // errorCode here to allow for testing the status check
+			this.strictLength = strictLength;
+			this.errorCode = errorCode;
+		}
 		
 		@Override
 		public void validate(final String fieldValue)
 				throws IllegalFieldValueException, FieldValidatorException {
+			requireNonNull(fieldValue, "fieldValue");
+			if (fieldValue.length() < MD5LEN) {
+				throw new IllegalFieldValueException(String.format(
+						"Gravatar hash less than %s characters", MD5LEN));
+			}
+			if (strictLength && fieldValue.length() > MD5LEN) {
+				throw new IllegalFieldValueException(String.format(
+						"Gravatar hash must be exactly %s characters", MD5LEN));
+			}
+			final Matcher m = MD5CHARS.matcher(fieldValue.substring(0, MD5LEN));
+			if (!m.find()) {
+				throw new IllegalFieldValueException("Gravatar hash is not a valid MD5 string");
+			}
+			
+			checkExists(fieldValue);
+		}
+	
+	private void checkExists(final String fieldValue)
+			throws IllegalFieldValueException, FieldValidatorException {
 			
 			final URI target = UriBuilder.fromUri(GURL).path(GPATH + fieldValue).build();
 			

--- a/src/us/kbase/test/groups/fieldvalidators/GravatarFieldValidatorFactoryTest.java
+++ b/src/us/kbase/test/groups/fieldvalidators/GravatarFieldValidatorFactoryTest.java
@@ -3,8 +3,11 @@ package us.kbase.test.groups.fieldvalidators;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Constructor;
+import java.util.Collections;
 
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 import us.kbase.groups.core.fieldvalidation.FieldValidator;
 import us.kbase.groups.core.fieldvalidation.FieldValidatorException;
@@ -19,7 +22,8 @@ public class GravatarFieldValidatorFactoryTest {
 	
 	@Test
 	public void validate() throws Exception {
-		final FieldValidator v = new GravatarFieldValidatorFactory().getValidator(null);
+		final FieldValidator v = new GravatarFieldValidatorFactory()
+				.getValidator(Collections.emptyMap());
 		
 		// if there's no error, the test passes
 		v.validate(KNOWN_GOOD);
@@ -28,37 +32,84 @@ public class GravatarFieldValidatorFactoryTest {
 	}
 	
 	@Test
+	public void validateStrictLength() throws Exception {
+		final FieldValidator v = new GravatarFieldValidatorFactory()
+				.getValidator(ImmutableMap.of("strict-length", "true"));
+		
+		// if there's no error, the test passes
+		v.validate(KNOWN_GOOD);
+	}
+	
+	@Test
 	public void validateFailBadHash() throws Exception {
-		final FieldValidator v = new GravatarFieldValidatorFactory().getValidator(null);
-		validateFail(v, KNOWN_GOOD.substring(0, LEN - 1)); // missing last char
-		validateFail(v, KNOWN_GOOD.substring(0, LEN - 1) + "c"); // incorrect last char
+		final FieldValidator v = new GravatarFieldValidatorFactory()
+				.getValidator(ImmutableMap.of("strict-length", "nottrue"));
+		
+		validateFail(v, null, new NullPointerException("fieldValue"));
+		validateFail(v, "  \t   ", new IllegalFieldValueException(
+				"Gravatar hash less than 32 characters"));
+		
+		validateFail(v, "                                ", new IllegalFieldValueException(
+				"Gravatar hash is not a valid MD5 string"));
+		final StringBuilder b = new StringBuilder(KNOWN_GOOD);
+		b.setCharAt(7, 'g');
+		validateFail(v, b.toString(), new IllegalFieldValueException(
+				"Gravatar hash is not a valid MD5 string"));
+		
+		// missing last char
+		validateFail(v, KNOWN_GOOD.substring(0, LEN - 1), new IllegalFieldValueException(
+				"Gravatar hash less than 32 characters"));
+		// incorrect last char
+		validateFail(v, KNOWN_GOOD.substring(0, LEN - 1) + "c", new IllegalFieldValueException(
+				"Gravatar service does not recognize Gravatar hash " +
+				KNOWN_GOOD.substring(0, LEN - 1) + "c"));
+	}
+	
+	@Test
+	public void validateFailStrictLength() throws Exception {
+		final FieldValidator v = new GravatarFieldValidatorFactory()
+				.getValidator(ImmutableMap.of("strict-length", "true"));
+		
+		validateFail(v, KNOWN_GOOD + "Z", new IllegalFieldValueException(
+				"Gravatar hash must be exactly 32 characters"));
 	}
 
-	private void validateFail(final FieldValidator v, final String value) throws Exception {
+	private void validateFail(
+			final FieldValidator v,
+			final String value,
+			final Exception expected) throws Exception {
 		
 		try {
 			v.validate(value);
 			fail("expected exception");
 		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new IllegalFieldValueException(
-					"Gravatar service does not recognize Gravatar hash " +
-					value));
+			TestCommon.assertExceptionCorrect(got, expected);
 		}
 	}
 	
 	@Test
 	public void validateFailGravatarError() throws Exception {
 		final Class<?> inner = GravatarFieldValidatorFactory.class.getDeclaredClasses()[0];
-		final Constructor<?> con = inner.getDeclaredConstructor(int.class);
+		final Constructor<?> con = inner.getDeclaredConstructor(boolean.class, int.class);
 		con.setAccessible(true);
-		final FieldValidator instance = (FieldValidator) con.newInstance(405);
+		final FieldValidator instance = (FieldValidator) con.newInstance(false, 405);
 		
 		try {
-			instance.validate("87194228ef49d635fec5938099042b1");
+			instance.validate(KNOWN_GOOD.substring(0, LEN - 1) + "c");
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new FieldValidatorException(
 					"Error contacting Gravatar service: 404"));
+		}
+	}
+	
+	@Test
+	public void getValidatorFail() throws Exception {
+		try {
+			new GravatarFieldValidatorFactory().getValidator(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("configuration"));
 		}
 	}
 


### PR DESCRIPTION
Now checks that the first 32 characters of the field are a valid MD5,
and optionally checks that the field is exactly 32 characters.