### PR TITLE
SCT-1486 Add DB methods for groups

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -275,6 +275,7 @@
         <test name="us.kbase.test.groups.core.GroupTest"/>
         <test name="us.kbase.test.groups.core.GroupCreationParamsTest"/>
         <test name="us.kbase.test.groups.core.GroupIDTest"/>
+      	<test name="us.kbase.test.groups.core.GroupIDAndNameTest"/>
         <test name="us.kbase.test.groups.core.GroupNameTest"/>
         <test name="us.kbase.test.groups.core.GroupsTest"/>
         <test name="us.kbase.test.groups.core.GroupUpdateParamsTest"/>

--- a/src/us/kbase/groups/core/GroupIDAndName.java
+++ b/src/us/kbase/groups/core/GroupIDAndName.java
@@ -1,0 +1,80 @@
+package us.kbase.groups.core;
+
+import static java.util.Objects.requireNonNull;
+
+/** A class consisting of the ID and name of a group with no other fields.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class GroupIDAndName {
+
+	private final GroupID id;
+	private final GroupName name;
+	
+	private GroupIDAndName(final GroupID id, final GroupName name) {
+		this.id = id;
+		this.name = name;
+	}
+	
+	/** Get the group ID.
+	 * @return the ID.
+	 */
+	public GroupID getID() {
+		return id;
+	}
+	
+	/** Get the group name.
+	 * @return the name.
+	 */
+	public GroupName getName() {
+		return name;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		GroupIDAndName other = (GroupIDAndName) obj;
+		if (id == null) {
+			if (other.id != null) {
+				return false;
+			}
+		} else if (!id.equals(other.id)) {
+			return false;
+		}
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		} else if (!name.equals(other.name)) {
+			return false;
+		}
+		return true;
+	}
+	
+	/** Create the ID and name container.
+	 * @param id the group ID.
+	 * @param name the group name.
+	 */
+	public static GroupIDAndName of(final GroupID id, final GroupName name) {
+		return new GroupIDAndName(requireNonNull(id, "id"), requireNonNull(name, "name"));
+	}
+	
+	
+}

--- a/src/us/kbase/groups/storage/GroupsStorage.java
+++ b/src/us/kbase/groups/storage/GroupsStorage.java
@@ -9,6 +9,7 @@ import us.kbase.groups.core.GetGroupsParams;
 import us.kbase.groups.core.GetRequestsParams;
 import us.kbase.groups.core.Group;
 import us.kbase.groups.core.GroupID;
+import us.kbase.groups.core.GroupIDAndName;
 import us.kbase.groups.core.GroupUpdateParams;
 import us.kbase.groups.core.GroupUser;
 import us.kbase.groups.core.Groups;
@@ -69,12 +70,28 @@ public interface GroupsStorage {
 	 */
 	Group getGroup(GroupID groupID) throws GroupsStorageException, NoSuchGroupException;
 	
+	/** Get the name of a group.
+	 * @param groupID the ID of the group.
+	 * @return the group name as well as the ID.
+	 * @throws GroupsStorageException if an error occurs contacting the storage system.
+	 * @throws NoSuchGroupException if there is not group with the given ID.
+	 */
+	GroupIDAndName getGroupName(GroupID groupID)
+			throws GroupsStorageException, NoSuchGroupException;
+	
 	/** Check whether a group exists.
 	 * @param groupID the ID of the group.
 	 * @return true if the group exists, false otherwise.
-	 * @throws GroupsStorageException
+	 * @throws GroupsStorageException if an error occurs contacting the storage system.
 	 */
 	boolean getGroupExists(GroupID groupID) throws GroupsStorageException;
+
+	/** Get the groups the member belongs to, up to a maximum of 100000 groups, sorted by ID.
+	 * @param user the user for whom groups will be returned.
+	 * @return the user's groups.
+	 * @throws GroupsStorageException if an error occurs contacting the storage system.
+	 */
+	List<GroupIDAndName> getMemberGroups(final UserName user) throws GroupsStorageException;
 	
 	/** Get groups in the system, sorted by the group ID.
 	 * At most 100 groups are returned.

--- a/src/us/kbase/test/groups/core/GroupIDAndNameTest.java
+++ b/src/us/kbase/test/groups/core/GroupIDAndNameTest.java
@@ -1,0 +1,45 @@
+package us.kbase.test.groups.core;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.groups.core.GroupID;
+import us.kbase.groups.core.GroupIDAndName;
+import us.kbase.groups.core.GroupName;
+import us.kbase.test.groups.TestCommon;
+
+public class GroupIDAndNameTest {
+	
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(GroupIDAndName.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void of() throws Exception {
+		final GroupIDAndName gin = GroupIDAndName.of(new GroupID("i"), new GroupName("n"));
+		
+		assertThat("incorrect id", gin.getID(), is(new GroupID("i")));
+		assertThat("incorrect id", gin.getName(), is(new GroupName("n")));
+	}
+	
+	@Test
+	public void ofFail() throws Exception {
+		ofFail(null, new GroupName("n"), new NullPointerException("id"));
+		ofFail(new GroupID("i"), null, new NullPointerException("name"));
+	}
+	
+	private void ofFail(final GroupID i, final GroupName n, final Exception expected) {
+		try {
+			GroupIDAndName.of(i, n);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+
+}


### PR DESCRIPTION
1) Get just the group name and id given the ID.

2) Get the group name and id for all a user's groups. This method will
be used for listing all of a user's group names at once, where you want
to minimize the data returned so the limit can be huge (100K in this
case).