### PR TITLE
SCT-1486 Add member endpoint to API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,12 +413,33 @@ PUT /group/<group id>/user/<user name>/update
 
 The user must be a group administrator or the user whose fields are to be updated.
 
-If a custom fields are missing, it is not altered.
+If custom fields are missing, they are not altered.
 If fields are `null`, they are removed. Otherwise they are set to the new value.
 
 See `Custom fields` below for information on custom fields.
 
 Whitespace only strings are treated as `null`.
+
+### Get a list of group IDs and names for which the user is a member
+
+```
+AUTHORIZATION REQUIRED
+GET /member/
+
+Returns:
+[{
+    "id": <group 1 id>,
+    "name": <group 1 name>
+ },
+ ...
+ {
+    "id": <group N id>,
+    "name": <group N name>
+ }]
+```
+
+*All* the groups for which the user is a member are returned in one response, which is why only
+the minimal amount of information per group is included.
 
 ### Add a resource to a group
 
@@ -668,10 +689,8 @@ Custom fields can also be applied to group members. To create a user field, subs
 field-user-myfield-validator=us.kbase.groups.fieldvalidators.SimpleFieldValidatorFactory
 ```
 
-All the previous field modifiers apply (using the `field-user-` prefix), but the group
-list setting only affects the owner's fields, since administrators and members are not
-visible in the group list, and the public modifier only affects the owner's and
-administrators' fields, since the members list is private.
+All the previous field modifiers apply (using the `field-user-` prefix) except for the group
+list setting, since user custom fields are not visible in the groups list.
 
 User fields have an additional setting that allows standard members, rather than only the owner
 and administrators, to set the field for their own record:

--- a/build.xml
+++ b/build.xml
@@ -310,6 +310,7 @@
         <test name="us.kbase.test.groups.service.LoggingFilterTest"/>
         <test name="us.kbase.test.groups.service.api.APICommonTest"/>
         <test name="us.kbase.test.groups.service.api.GroupsAPITest"/>
+      	<test name="us.kbase.test.groups.service.api.MemberAPITest"/>
         <test name="us.kbase.test.groups.service.api.RequestAPITest"/>
         <test name="us.kbase.test.groups.service.api.RootTest"/>
         <test name="us.kbase.test.groups.service.api.IncomingJSONTest"/>

--- a/src/us/kbase/groups/service/api/MemberAPI.java
+++ b/src/us/kbase/groups/service/api/MemberAPI.java
@@ -1,0 +1,51 @@
+package us.kbase.groups.service.api;
+
+import static us.kbase.groups.service.api.APICommon.getToken;
+import static us.kbase.groups.service.api.APIConstants.HEADER_TOKEN;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.groups.core.Groups;
+import us.kbase.groups.core.exceptions.AuthenticationException;
+import us.kbase.groups.core.exceptions.IllegalParameterException;
+import us.kbase.groups.core.exceptions.InvalidTokenException;
+import us.kbase.groups.core.exceptions.NoTokenProvidedException;
+import us.kbase.groups.storage.exceptions.GroupsStorageException;
+
+@Path(ServicePaths.MEMBER)
+public class MemberAPI {
+
+	// TODO JAVADOC / swagger
+	
+	private final Groups groups;
+	
+	// normally instantiated by Jersey
+	@Inject
+	public MemberAPI(final Groups groups) {
+		this.groups = groups;
+	}
+	
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public List<Map<String, String>> getMemberGroups(
+			@HeaderParam(HEADER_TOKEN) final String token)
+			throws GroupsStorageException, IllegalParameterException, NoTokenProvidedException,
+				InvalidTokenException, AuthenticationException {
+		return groups.getMemberGroups(getToken(token, true))
+				.stream().map(g -> ImmutableMap.of(
+						Fields.GROUP_ID, g.getID().getName(),
+						Fields.GROUP_NAME, g.getName().getName()))
+				.collect(Collectors.toList());
+	}	
+}

--- a/src/us/kbase/groups/service/api/ServicePaths.java
+++ b/src/us/kbase/groups/service/api/ServicePaths.java
@@ -70,5 +70,8 @@ public class ServicePaths {
 	/** The location to list requests targeted at the user. */
 	public static final String REQUEST_TARGETED = SEP + "targeted";
 	
+	/* Member endpoints */
 	
+	/** The member endpoint location. */
+	public static final String MEMBER = SEP + "member";
 }

--- a/src/us/kbase/test/groups/service/api/MemberAPITest.java
+++ b/src/us/kbase/test/groups/service/api/MemberAPITest.java
@@ -1,0 +1,56 @@
+package us.kbase.test.groups.service.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.groups.core.GroupID;
+import us.kbase.groups.core.GroupIDAndName;
+import us.kbase.groups.core.GroupName;
+import us.kbase.groups.core.Groups;
+import us.kbase.groups.core.Token;
+import us.kbase.groups.core.exceptions.NoTokenProvidedException;
+import us.kbase.groups.service.api.MemberAPI;
+import us.kbase.test.groups.TestCommon;
+
+public class MemberAPITest {
+
+	@Test
+	public void getMemberGroups() throws Exception {
+		final Groups g = mock(Groups.class);
+		
+		final MemberAPI mapi = new MemberAPI(g);
+		
+		when(g.getMemberGroups(new Token("tok"))).thenReturn(Arrays.asList(
+				GroupIDAndName.of(new GroupID("id1"), new GroupName("n1")),
+				GroupIDAndName.of(new GroupID("id2"), new GroupName("n2"))));
+		
+		assertThat("incorrect groups", mapi.getMemberGroups("tok"), is(Arrays.asList(
+				ImmutableMap.of("id", "id1", "name", "n1"),
+				ImmutableMap.of("id", "id2", "name", "n2"))));
+	}
+	
+	@Test
+	public void failGetMemberGroups() throws Exception {
+		failGetMemberGroups(null, new NoTokenProvidedException("No token provided"));
+		failGetMemberGroups("   \t   ", new NoTokenProvidedException("No token provided"));
+	}
+
+	private void failGetMemberGroups(final String t, Exception expected) {
+		try {
+			new MemberAPI(mock(Groups.class)).getMemberGroups(t);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+}


### PR DESCRIPTION
Allows getting IDs and names for all groups where the user is a member.

Also some README fixes.