### PR TITLE
Fix private admin'd resources bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ RETURNS: A Group.
 ```
 
 If the user is not a member of the group or no authorization is provided and the group is
-private, only the `groupid`, `private`, and `role` fields are included.
+private, only the `groupid`, `private`, `role`, and `resources` fields are included. Only
+resources the user user administrates will be available in `resources`.
 
 If no authorization is provided, the members list is populated or not based on the
 `privatemembers` field, only public custom fields are included, and only public resources

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # KBase Groups Service release notes
 
+## 0.1.6
+
+* Fixed a bug where resource administrators could not see their resources in private groups
+  for which they were not a member in the `/group/<group id> endpoint`.
+
 ## 0.1.5
 
 * Group administrators may now promote and demote other administrators.

--- a/src/us/kbase/groups/cataloghandler/SDKClientCatalogHandler.java
+++ b/src/us/kbase/groups/cataloghandler/SDKClientCatalogHandler.java
@@ -1,14 +1,17 @@
 package us.kbase.groups.cataloghandler;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static us.kbase.groups.util.Util.checkNoNullsInCollection;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import us.kbase.catalog.BasicModuleInfo;
 import us.kbase.catalog.CatalogClient;
@@ -22,6 +25,7 @@ import us.kbase.groups.core.exceptions.IllegalResourceIDException;
 import us.kbase.groups.core.exceptions.MissingParameterException;
 import us.kbase.groups.core.exceptions.NoSuchResourceException;
 import us.kbase.groups.core.exceptions.ResourceHandlerException;
+import us.kbase.groups.core.resource.ResourceAccess;
 import us.kbase.groups.core.resource.ResourceAdministrativeID;
 import us.kbase.groups.core.resource.ResourceDescriptor;
 import us.kbase.groups.core.resource.ResourceHandler;
@@ -191,17 +195,43 @@ public class SDKClientCatalogHandler implements ResourceHandler {
 	@Override
 	public ResourceInformationSet getResourceInformation(
 			final UserName user,
-			final Set<ResourceID> resources,
-			final boolean administratedResourcesOnly)
-			throws IllegalResourceIDException {
+			Set<ResourceID> resources,
+			final ResourceAccess access)
+			throws IllegalResourceIDException, ResourceHandlerException {
 		checkNoNullsInCollection(resources, "resources");
-		final Builder b = ResourceInformationSet.getBuilder(user);
-		
+		requireNonNull(access, "access");
 		for (final ResourceID r: resources) {
-			getModMeth(r); // check id is valid
-			b.withResource(r);
+			getModMeth(r); // check ids are valid before we do anything else
 		}
+		// check != so that if another level is added to ResourceAccess it doesn't
+		// accidentally grant access
+		if (!ResourceAccess.ALL.equals(access) &&
+				!ResourceAccess.ADMINISTRATED_AND_PUBLIC.equals(access)) {
+			if (user == null) {
+				resources = Collections.emptySet();
+			} else {
+				resources = filterNonAdministrated(resources, user);
+			}
+		}
+		final Builder b = ResourceInformationSet.getBuilder(user);
+		resources.stream().forEach(r -> b.withResource(r));
 		return b.build();
+	}
+
+	private Set<ResourceID> filterNonAdministrated(
+			final Set<ResourceID> resources,
+			final UserName user)
+			throws ResourceHandlerException, IllegalResourceIDException {
+		// there are no bulk methods for getting catalog methods, so just list all admin'd mods
+		final Set<String> admined = getAdministratedResources(user).stream().map(r -> r.getName())
+				.collect(Collectors.toSet());
+		final Set<ResourceID> ret = new HashSet<>();
+		for (final ResourceID r: resources) {
+			if (admined.contains(getModMeth(r).mod)) {
+				ret.add(r);
+			}
+		}
+		return ret;
 	}
 
 	@Override

--- a/src/us/kbase/groups/core/GroupView.java
+++ b/src/us/kbase/groups/core/GroupView.java
@@ -185,7 +185,8 @@ public class GroupView {
 		this.isPrivate = group.isPrivate();
 		this.groupID = group.getGroupID();
 		if (isPrivateView()) {
-			this.resourceInfo = Collections.emptyMap();
+			// resInfo is expected to only contain admin'd resources for non-members
+			this.resourceInfo = Collections.unmodifiableMap(resourceInfo);
 			this.resourceJoinDate = Collections.emptyMap();
 			this.groupName = Optional.empty();
 			this.owner = Optional.empty();
@@ -659,6 +660,7 @@ public class GroupView {
 		/** Add resource information to the view. The resource type and the resource IDs for
 		 * that type must exist in the group, and the information set may not include
 		 * nonexistent resources.
+		 * The resource information will be visible to any user able to access this object.
 		 * Calling this method will overwrite any previous information for the type.
 		 * @param type the type of the resource.
 		 * @param info the information for the resource.

--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -50,6 +50,7 @@ import us.kbase.groups.core.request.GroupRequestUserAction;
 import us.kbase.groups.core.request.GroupRequestWithActions;
 import us.kbase.groups.core.request.RequestID;
 import us.kbase.groups.core.request.RequestType;
+import us.kbase.groups.core.resource.ResourceAccess;
 import us.kbase.groups.core.resource.ResourceAdministrativeID;
 import us.kbase.groups.core.resource.ResourceDescriptor;
 import us.kbase.groups.core.resource.ResourceHandler;
@@ -402,7 +403,7 @@ public class Groups {
 					user,
 					g.getResources(type).stream().map(r -> r.getResourceID())
 							.collect(Collectors.toSet()),
-					!g.isMember(user));
+					getAccessLevel(g, user));
 		} catch (IllegalResourceIDException e) {
 			throw new RuntimeException(String.format(
 					"Illegal data associated with group %s: %s",
@@ -416,6 +417,16 @@ public class Groups {
 			}
 		}
 		return info;
+	}
+
+	private ResourceAccess getAccessLevel(final Group g, final UserName user) {
+		if (g.isMember(user)) {
+			return ResourceAccess.ALL;
+		} else if (!g.isPrivate()) {
+			return ResourceAccess.ADMINISTRATED_AND_PUBLIC;
+		} else {
+			return ResourceAccess.ADMINISTRATED;
+		}
 	}
 
 	/** Check if a group exists based on the group ID.

--- a/src/us/kbase/groups/core/resource/ResourceAccess.java
+++ b/src/us/kbase/groups/core/resource/ResourceAccess.java
@@ -1,0 +1,18 @@
+package us.kbase.groups.core.resource;
+
+/** An enum designating what resources should be made available to a user.
+ * @author gaprice@lbl.gov
+ *
+ */
+public enum ResourceAccess {
+	
+	/** All resources. */
+	ALL,
+	
+	/** Resources administrated by the user and public resources. */
+	ADMINISTRATED_AND_PUBLIC,
+	
+	/** Resources administrated by the user. */
+	ADMINISTRATED;
+
+}

--- a/src/us/kbase/groups/core/resource/ResourceHandler.java
+++ b/src/us/kbase/groups/core/resource/ResourceHandler.java
@@ -59,8 +59,8 @@ public interface ResourceHandler {
 	 * @param user the user at which any user-specific fields should be targeted. If null,
 	 * indicating an anonymous user, only public resources are returned.
 	 * @param resources the resources to retrieve.
-	 * @param administratedResourcesOnly if true, only return public resources and resources
-	 * the user administrates. If false, return all resources (unless the user is null).
+	 * @param access the level of access to the resources the user possesses. Note that
+	 * an anonymous user will, in most cases, administrate no resources.
 	 * @return the resource information.
 	 * @throws IllegalResourceIDException if the resource ID is not in a legal format.
 	 * @throws ResourceHandlerException if an error occurs contacting the resource service.
@@ -68,7 +68,7 @@ public interface ResourceHandler {
 	ResourceInformationSet getResourceInformation(
 			UserName user,
 			Set<ResourceID> resources,
-			boolean administratedResourcesOnly)
+			ResourceAccess access)
 			throws IllegalResourceIDException, ResourceHandlerException;
 
 	/** Grant a user permission to view or read a resource, if the user does not already have

--- a/src/us/kbase/groups/service/api/APICommon.java
+++ b/src/us/kbase/groups/service/api/APICommon.java
@@ -80,6 +80,13 @@ public class APICommon {
 		ret.put(Fields.GROUP_ID, group.getGroupID().getName());
 		ret.put(Fields.GROUP_IS_PRIVATE, group.isPrivate());
 		ret.put(Fields.GROUP_ROLE, group.getRole().getRepresentation());
+		if (group.isStandardView()) {
+			final Map<String, Object> resources = new HashMap<>();
+			ret.put(Fields.GROUP_RESOURCES, resources);
+			for (final ResourceType t: group.getResourceTypes()) {
+				resources.put(t.getName(), getResourceList(group, t));
+			}
+		}
 		if (!group.isPrivateView()) {
 			ret.put(Fields.GROUP_NAME, group.getGroupName().get().getName());
 			ret.put(Fields.GROUP_OWNER, group.getOwner().get().getName());
@@ -98,11 +105,6 @@ public class APICommon {
 				ret.put(Fields.GROUP_OWNER, toUserJson(group.getMember(group.getOwner().get())));
 				ret.put(Fields.GROUP_MEMBERS, toMemberList(group.getMembers(), group));
 				ret.put(Fields.GROUP_ADMINS, toMemberList(group.getAdministrators(), group));
-				final Map<String, Object> resources = new HashMap<>();
-				ret.put(Fields.GROUP_RESOURCES, resources);
-				for (final ResourceType t: group.getResourceTypes()) {
-					resources.put(t.getName(), getResourceList(group, t));
-				}
 			}
 		}
 		return ret;

--- a/src/us/kbase/groups/service/api/Root.java
+++ b/src/us/kbase/groups/service/api/Root.java
@@ -26,7 +26,7 @@ public class Root {
 	//TODO ZLATER ROOT add configurable contact email or link
 	//TODO ZLATER swagger
 	
-	private static final String VERSION = "0.1.5";
+	private static final String VERSION = "0.1.6-dev1";
 	private static final String SERVER_NAME = "Groups service";
 	
 	/** Return the root information.

--- a/src/us/kbase/test/groups/core/GroupViewTest.java
+++ b/src/us/kbase/test/groups/core/GroupViewTest.java
@@ -418,7 +418,18 @@ public class GroupViewTest {
 		assertThat("incorrect own", gv.getOwner(), is(mt()));
 		assertThat("incorrect view type", gv.isStandardView(), is(true));
 		assertThat("incorrect role", gv.getRole(), is(Group.Role.NONE));
-		assertThat("incorrect types", gv.getResourceTypes(), is(set()));
+		assertThat("incorrect types", gv.getResourceTypes(), is(set(new ResourceType("bar"),
+				new ResourceType("workspace"), new ResourceType("catalogmethod"))));
+		assertThat("incorrect info", gv.getResourceInformation(new ResourceType("bar")),
+				is(ResourceInformationSet.getBuilder(null).build()));
+		assertThat("incorrect info", gv.getResourceInformation(new ResourceType("workspace")),
+				is(ResourceInformationSet.getBuilder(null)
+						.withResource(new ResourceID("7"))
+						.build()));
+		assertThat("incorrect info", gv.getResourceInformation(new ResourceType("catalogmethod")),
+				is(ResourceInformationSet.getBuilder(null)
+						.build()));
+		
 		assertThat("incorrect custom", gv.getCustomFields(), is(Collections.emptyMap()));
 		
 		getMemberFail(gv, new UserName("user"));

--- a/src/us/kbase/test/groups/integration/ServiceIntegrationTest.java
+++ b/src/us/kbase/test/groups/integration/ServiceIntegrationTest.java
@@ -411,7 +411,12 @@ public class ServiceIntegrationTest {
 		final Map<String, Object> g = res.readEntity(Map.class);
 		
 		assertThat("group is not private", g, is(ImmutableMap.of(
-				"id", groupID, "private", true, "role", "None")));
+				"id", groupID,
+				"private", true,
+				"role", "None",
+				"resources", ImmutableMap.of(
+						"catalogmethod", Collections.emptyList(),
+						"workspace", Collections.emptyList()))));
 	}
 	
 	private void assertGroupExists(final String gid, boolean exists) {

--- a/src/us/kbase/test/groups/service/api/APICommonTest.java
+++ b/src/us/kbase/test/groups/service/api/APICommonTest.java
@@ -514,6 +514,35 @@ public class APICommonTest {
 	}
 	
 	@Test
+	public void toGroupJSONStandardViewResourcesNonMemberPrivate() throws Exception {
+		final UserName userName = new UserName("non");
+		final GroupView gv = GroupView.getBuilder(
+				getGroupMaxBuilder()
+				.withIsPrivate(true)
+				.build(),
+				userName)
+				.withResource(new ResourceType("ws"), ResourceInformationSet
+						.getBuilder(userName)
+						.withResourceField(new ResourceID("a"), "f1", "x")
+						.build())
+				.withStandardView(true)
+				.build();
+		
+		assertThat("incorrect JSON", APICommon.toGroupJSON(gv), is(MapBuilder.newHashMap()
+				.with("id", "id2")
+				.with("private", true)
+				.with("role", "None")
+				.with("resources", ImmutableMap.of(
+						"ws", Arrays.asList(
+								MapBuilder.newHashMap()
+										.with("rid", "a")
+										.with("added", null)
+										.with("f1", "x")
+										.build())))
+				.build()));
+	}
+	
+	@Test
 	public void toGroupJSONFail() throws Exception {
 		try {
 			APICommon.toGroupJSON(null);

--- a/src/us/kbase/test/groups/service/api/GroupsAPITest.java
+++ b/src/us/kbase/test/groups/service/api/GroupsAPITest.java
@@ -262,6 +262,7 @@ public class GroupsAPITest {
 			.with("id", "id2")
 			.with("private", true)
 			.with("role", "None")
+			.with("resources", Collections.emptyMap())
 			.build();
 
 	@Test

--- a/src/us/kbase/test/groups/service/api/RootTest.java
+++ b/src/us/kbase/test/groups/service/api/RootTest.java
@@ -17,7 +17,7 @@ import us.kbase.test.groups.TestCommon;
 
 public class RootTest {
 	
-	public static final String SERVER_VER = "0.1.5";
+	public static final String SERVER_VER = "0.1.6-dev1";
 	private static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.groups";
 	

--- a/src/us/kbase/test/groups/workspacehandler/SDKClientWorkspaceHandlerTest.java
+++ b/src/us/kbase/test/groups/workspacehandler/SDKClientWorkspaceHandlerTest.java
@@ -344,6 +344,58 @@ public class SDKClientWorkspaceHandlerTest {
 	}
 	
 	@Test
+	public void getResourceInformationFullAnonUser() throws Exception {
+		getResourceInformation(
+				null,
+				ResourceAccess.ALL,
+				ResourceInformationSet.getBuilder(null)
+						.withNonexistentResource(RD8)
+						.withNonexistentResource(RD9)
+						.withNonexistentResource(RD20)
+						.withNonexistentResource(RD21)
+						.withNonexistentResource(RD30)
+						.withNonexistentResource(RD31)
+						.withNonexistentResource(RD40)
+						.withNonexistentResource(RD41)
+						.withResourceField(RD3, "name", "name3")
+						.withResourceField(RD3, "public", false)
+						.withResourceField(RD3, "narrname", null)
+						.withResourceField(RD3, "narrcreate", null)
+						.withResourceField(RD3, "perm", "None")
+						.withResourceField(RD3, "description", "my desc")
+						.withResourceField(RD3, "moddate", 1540606613000L)
+						.withResourceField(RD5, "name", "name5")
+						.withResourceField(RD5, "public", false)
+						.withResourceField(RD5, "narrname", "narr_name")
+						.withResourceField(RD5, "narrcreate", 1500000000000L)
+						.withResourceField(RD5, "perm", "None")
+						.withResourceField(RD5, "description", null)
+						.withResourceField(RD5, "moddate", 0L)
+						.withResourceField(RD7, "name", "name7")
+						.withResourceField(RD7, "public", false)
+						.withResourceField(RD7, "narrname", null)
+						.withResourceField(RD7, "narrcreate", null)
+						.withResourceField(RD7, "perm", "None")
+						.withResourceField(RD7, "description", "my desc7")
+						.withResourceField(RD7, "moddate", 31535999000L)
+						.withResourceField(RD10, "name", "name10")
+						.withResourceField(RD10, "public", true)
+						.withResourceField(RD10, "narrname", null)
+						.withResourceField(RD10, "narrcreate", null)
+						.withResourceField(RD10, "perm", "None")
+						.withResourceField(RD10, "description", "my desc10")
+						.withResourceField(RD10, "moddate", 1500000000000L)
+						.withResourceField(RD11, "name", "name11")
+						.withResourceField(RD11, "public", true)
+						.withResourceField(RD11, "narrname", null)
+						.withResourceField(RD11, "narrcreate", null)
+						.withResourceField(RD11, "perm", "None")
+						.withResourceField(RD11, "description", "my desc11")
+						.withResourceField(RD11, "moddate", 549864182000L)
+						.build());
+	}
+	
+	@Test
 	public void getResourceInformationAdminPublic() throws Exception {
 		getResourceInformation(
 				new UserName("user1"),
@@ -388,6 +440,36 @@ public class SDKClientWorkspaceHandlerTest {
 	}
 	
 	@Test
+	public void getResourceInformationAdminPublicAnonUser() throws Exception {
+		getResourceInformation(
+		null,
+		ResourceAccess.ADMINISTRATED_AND_PUBLIC,
+		ResourceInformationSet.getBuilder(null)
+				.withNonexistentResource(RD9)
+				.withNonexistentResource(RD20)
+				.withNonexistentResource(RD21)
+				.withNonexistentResource(RD30)
+				.withNonexistentResource(RD31)
+				.withNonexistentResource(RD40)
+				.withNonexistentResource(RD41)
+				.withResourceField(RD10, "name", "name10")
+				.withResourceField(RD10, "public", true)
+				.withResourceField(RD10, "narrname", null)
+				.withResourceField(RD10, "narrcreate", null)
+				.withResourceField(RD10, "perm", "None")
+				.withResourceField(RD10, "description", "my desc10")
+				.withResourceField(RD10, "moddate", 1500000000000L)
+				.withResourceField(RD11, "name", "name11")
+				.withResourceField(RD11, "public", true)
+				.withResourceField(RD11, "narrname", null)
+				.withResourceField(RD11, "narrcreate", null)
+				.withResourceField(RD11, "perm", "None")
+				.withResourceField(RD11, "description", "my desc11")
+				.withResourceField(RD11, "moddate", 549864182000L)
+				.build());
+	}
+	
+	@Test
 	public void getResourceInformationAdmin() throws Exception {
 		getResourceInformation(
 				new UserName("user1"),
@@ -413,40 +495,16 @@ public class SDKClientWorkspaceHandlerTest {
 	}
 	
 	@Test
-	public void getResourceInformationAnonUser() throws Exception {
-		getResourceInformationAnonUser(ResourceAccess.ADMINISTRATED_AND_PUBLIC);
-	}
-	
-	private void getResourceInformationAnonUser(final ResourceAccess access)
-			throws Exception {
+	public void getResourceInformationAdminAnonUser() throws Exception {
 		getResourceInformation(
 				null,
-				access,
+				ResourceAccess.ADMINISTRATED,
 				ResourceInformationSet.getBuilder(null)
-						.withNonexistentResource(RD9)
 						.withNonexistentResource(RD20)
 						.withNonexistentResource(RD21)
-						.withNonexistentResource(RD30)
-						.withNonexistentResource(RD31)
-						.withNonexistentResource(RD40)
-						.withNonexistentResource(RD41)
-						.withResourceField(RD10, "name", "name10")
-						.withResourceField(RD10, "public", true)
-						.withResourceField(RD10, "narrname", null)
-						.withResourceField(RD10, "narrcreate", null)
-						.withResourceField(RD10, "perm", "None")
-						.withResourceField(RD10, "description", "my desc10")
-						.withResourceField(RD10, "moddate", 1500000000000L)
-						.withResourceField(RD11, "name", "name11")
-						.withResourceField(RD11, "public", true)
-						.withResourceField(RD11, "narrname", null)
-						.withResourceField(RD11, "narrcreate", null)
-						.withResourceField(RD11, "perm", "None")
-						.withResourceField(RD11, "description", "my desc11")
-						.withResourceField(RD11, "moddate", 549864182000L)
 						.build());
 	}
-
+	
 	private void getResourceInformation(
 			final UserName user,
 			final ResourceAccess access,

--- a/src/us/kbase/test/groups/workspacehandler/SDKClientWorkspaceHandlerTest.java
+++ b/src/us/kbase/test/groups/workspacehandler/SDKClientWorkspaceHandlerTest.java
@@ -33,6 +33,7 @@ import us.kbase.groups.core.UserName;
 import us.kbase.groups.core.exceptions.IllegalResourceIDException;
 import us.kbase.groups.core.exceptions.NoSuchResourceException;
 import us.kbase.groups.core.exceptions.ResourceHandlerException;
+import us.kbase.groups.core.resource.ResourceAccess;
 import us.kbase.groups.core.resource.ResourceAdministrativeID;
 import us.kbase.groups.core.resource.ResourceDescriptor;
 import us.kbase.groups.core.resource.ResourceID;
@@ -284,7 +285,7 @@ public class SDKClientWorkspaceHandlerTest {
 		final SDKClientWorkspaceHandler h = new SDKClientWorkspaceHandler(c);
 		
 		final ResourceInformationSet wi = h.getResourceInformation(
-				new UserName("u"), set(), false);
+				new UserName("u"), set(), ResourceAccess.ALL);
 		
 		assertThat("incorrect wsi", wi, is(ResourceInformationSet.getBuilder(new UserName("u"))
 				.build()));
@@ -294,7 +295,7 @@ public class SDKClientWorkspaceHandlerTest {
 	public void getResourceInformationFull() throws Exception {
 		getResourceInformation(
 				new UserName("user1"),
-				false,
+				ResourceAccess.ALL,
 				ResourceInformationSet.getBuilder(new UserName("user1"))
 						.withNonexistentResource(RD8)
 						.withNonexistentResource(RD9)
@@ -343,10 +344,10 @@ public class SDKClientWorkspaceHandlerTest {
 	}
 	
 	@Test
-	public void getResourceInformationAdministratedOnly() throws Exception {
+	public void getResourceInformationAdminPublic() throws Exception {
 		getResourceInformation(
 				new UserName("user1"),
-				true,
+				ResourceAccess.ADMINISTRATED_AND_PUBLIC,
 				ResourceInformationSet.getBuilder(new UserName("user1"))
 						.withNonexistentResource(RD9)
 						.withNonexistentResource(RD20)
@@ -387,20 +388,40 @@ public class SDKClientWorkspaceHandlerTest {
 	}
 	
 	@Test
-	public void getResourceInformationAnonUser() throws Exception {
-		getResourceInformationAnonUser(false);
+	public void getResourceInformationAdmin() throws Exception {
+		getResourceInformation(
+				new UserName("user1"),
+				ResourceAccess.ADMINISTRATED,
+				ResourceInformationSet.getBuilder(new UserName("user1"))
+						.withNonexistentResource(RD20)
+						.withNonexistentResource(RD21)
+						.withResourceField(RD3, "name", "name3")
+						.withResourceField(RD3, "public", false)
+						.withResourceField(RD3, "narrname", null)
+						.withResourceField(RD3, "narrcreate", null)
+						.withResourceField(RD3, "perm", "Own")
+						.withResourceField(RD3, "description", "my desc")
+						.withResourceField(RD3, "moddate", 1540606613000L)
+						.withResourceField(RD5, "name", "name5")
+						.withResourceField(RD5, "public", false)
+						.withResourceField(RD5, "narrname", "narr_name")
+						.withResourceField(RD5, "narrcreate", 1500000000000L)
+						.withResourceField(RD5, "perm", "Admin")
+						.withResourceField(RD5, "description", null)
+						.withResourceField(RD5, "moddate", 0L)
+						.build());
 	}
 	
 	@Test
-	public void getResourceInformationAnonUserAdministratedWSOnly() throws Exception {
-		getResourceInformationAnonUser(true);
+	public void getResourceInformationAnonUser() throws Exception {
+		getResourceInformationAnonUser(ResourceAccess.ADMINISTRATED_AND_PUBLIC);
 	}
-
-	private void getResourceInformationAnonUser(final boolean administratedWorkspacesOnly)
+	
+	private void getResourceInformationAnonUser(final ResourceAccess access)
 			throws Exception {
 		getResourceInformation(
 				null,
-				administratedWorkspacesOnly,
+				access,
 				ResourceInformationSet.getBuilder(null)
 						.withNonexistentResource(RD9)
 						.withNonexistentResource(RD20)
@@ -428,7 +449,7 @@ public class SDKClientWorkspaceHandlerTest {
 
 	private void getResourceInformation(
 			final UserName user,
-			final boolean administratedResourcesOnly,
+			final ResourceAccess access,
 			final ResourceInformationSet expected)
 			throws Exception {
 		final WorkspaceClient c = mock(WorkspaceClient.class);
@@ -566,7 +587,7 @@ public class SDKClientWorkspaceHandlerTest {
 						new ResourceID("11"), new ResourceID("20"), new ResourceID("21"),
 						new ResourceID("30"), new ResourceID("31"),
 						new ResourceID("40"), new ResourceID("41")),
-				administratedResourcesOnly);
+				access);
 		
 		assertThat("incorrect resources", ri, is(expected));
 	}
@@ -630,11 +651,13 @@ public class SDKClientWorkspaceHandlerTest {
 		when(c.ver()).thenReturn(MIN_WS_VER);
 		
 		final SDKClientWorkspaceHandler h = new SDKClientWorkspaceHandler(c);
+		final ResourceAccess a = ResourceAccess.ALL;
 		
-		failGetResourceInfo(h, null, new NullPointerException("resources"));
-		failGetResourceInfo(h, set(new ResourceID("1"), null),
+		failGetResourceInfo(h, null, a, new NullPointerException("resources"));
+		failGetResourceInfo(h, set(new ResourceID("1"), null), a,
 				new NullPointerException("Null item in collection resources"));
-		failGetResourceInfo(h, set(new ResourceID("bar")),
+		failGetResourceInfo(h, set(), null, new NullPointerException("access"));
+		failGetResourceInfo(h, set(new ResourceID("bar")), a,
 				new IllegalResourceIDException("bar"));
 	}
 	
@@ -679,7 +702,7 @@ public class SDKClientWorkspaceHandlerTest {
 		
 		when(c.administer(argThat(getPermissionsCommandMatcher(24)))).thenThrow(thrown);
 		
-		failGetResourceInfo(h, set(new ResourceID("24")), expected);
+		failGetResourceInfo(h, set(new ResourceID("24")), ResourceAccess.ALL, expected);
 	}
 	
 	@Test
@@ -727,7 +750,7 @@ public class SDKClientWorkspaceHandlerTest {
 
 		doThrow(thrown).when(c).administer(argThat(getWSInfoCommandMatcher(24)));
 		
-		failGetResourceInfo(h, set(new ResourceID("24")), expected);
+		failGetResourceInfo(h, set(new ResourceID("24")), ResourceAccess.ALL, expected);
 	}
 	
 	@Test
@@ -779,7 +802,7 @@ public class SDKClientWorkspaceHandlerTest {
 		
 		doThrow(thrown).when(c).administer(argThat(getWSDescCommandMatcher(24)));
 		
-		failGetResourceInfo(h, set(new ResourceID("24")), expected);
+		failGetResourceInfo(h, set(new ResourceID("24")), ResourceAccess.ALL, expected);
 	}
 	
 	@Test
@@ -852,16 +875,17 @@ public class SDKClientWorkspaceHandlerTest {
 		
 		doThrow(thrown).when(c).administer(argThat(getObjectInfoCommandMatcher(24, 4, 1)));
 		
-		failGetResourceInfo(h, set(new ResourceID("24")), expected);
+		failGetResourceInfo(h, set(new ResourceID("24")), ResourceAccess.ALL, expected);
 	}
 	
 	private void failGetResourceInfo(
 			final SDKClientWorkspaceHandler h,
 			final Set<ResourceID> ids,
+			final ResourceAccess access,
 			final Exception expected) {
 		try {
 			// no way to cause a fail via user or adminOnly param
-			h.getResourceInformation(null, ids, false);
+			h.getResourceInformation(null, ids, access);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, expected);


### PR DESCRIPTION
Expose resources the user administrates in private groups. Public resources are not exposed.

As usual, members can see all resources.

@eapearson