### PR TITLE
SCT-1806 Add resource type & id to list request parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@
 
 ## 0.1.2
 
-* BACKWARDS INCOMPATIBILITY: The /request/groups/<ids>/new endpoint no longer accepts a
+* BACKWARDS INCOMPATIBILITY: The `/request/groups/<ids>/new` endpoint no longer accepts a
   `laterthan` date and bases the old vs. new request determination on the last visited date
   for the group.
 
@@ -32,12 +32,12 @@
 * BACKWARDS INCOMPATIBILITY: The user role enum values are now capitalized like all the other
   enums in the API, e.g. None, Member, Admin, and Owner.
 
-* Added a /request/id/<id>/group endpoint that returns minimal group information for Invite-type
-  requests.
-* Added a /request/groups/<csv ids>/new endpoint that returns whether a set of groups have
+* Added a `/request/id/<id>/group` endpoint that returns minimal group information for
+  Invite-type requests.
+* Added a `/request/groups/<csv ids>/new` endpoint that returns whether a set of groups have
   open requests on a per group basis.
-* Added a /group/<id>/visit endpoint that sets the last visited date for the current user for the
-  group, and added the last visited date to the API.
+* Added a `/group/<id>/visit` endpoint that sets the last visited date for the current user for
+  the group, and added the last visited date to the API.
 
 ## 0.1.0
 

--- a/src/us/kbase/groups/core/GetRequestsParams.java
+++ b/src/us/kbase/groups/core/GetRequestsParams.java
@@ -1,10 +1,14 @@
 package us.kbase.groups.core;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.Instant;
 import java.util.Optional;
 
 import us.kbase.groups.core.request.GroupRequest;
 import us.kbase.groups.core.request.GroupRequestStatusType;
+import us.kbase.groups.core.resource.ResourceID;
+import us.kbase.groups.core.resource.ResourceType;
 
 /** A set of parameters for use when listing {@link GroupRequest}s.
  * @author gaprice@lbl.gov
@@ -15,14 +19,20 @@ public class GetRequestsParams {
 	private final boolean includeClosed;
 	private final boolean sortAscending;
 	private final Optional<Instant> excludeUpTo;
+	private final Optional<ResourceType> resourceType;
+	private final Optional<ResourceID> resourceID;
 	
 	private GetRequestsParams(
 			final boolean includeClosed,
 			final boolean sortAscending,
-			final Optional<Instant> excludeUpTo) {
+			final Optional<Instant> excludeUpTo,
+			final Optional<ResourceType> resourceType,
+			final Optional<ResourceID> resourceID) {
 		this.includeClosed = includeClosed;
 		this.sortAscending = sortAscending;
 		this.excludeUpTo = excludeUpTo;
+		this.resourceType = resourceType;
+		this.resourceID = resourceID;
 	}
 
 	/** Get whether closed requests should be included in the list. Any request with a status type
@@ -48,6 +58,24 @@ public class GetRequestsParams {
 	public Optional<Instant> getExcludeUpTo() {
 		return excludeUpTo;
 	}
+	
+	/** Get the resource type that must limit the list of requests. If the type is present,
+	 * {@link #getResourceID()} will always return a resource ID. The combination of the two
+	 * must limit the list of requests.
+	 * @return the resource type that all the requests must possess.
+	 */
+	public Optional<ResourceType> getResourceType() {
+		return resourceType;
+	}
+	
+	/** Get the resource ID that must limit the list of requests. If the ID is present,
+	 * {@link #getResourceType()} will always return a resource type. The combination of the two
+	 * must limit the list of requests.
+	 * @return the resource ID that all the requests must possess.
+	 */
+	public Optional<ResourceID> getResourceID() {
+		return resourceID;
+	}
 
 	@Override
 	public int hashCode() {
@@ -55,6 +83,8 @@ public class GetRequestsParams {
 		int result = 1;
 		result = prime * result + ((excludeUpTo == null) ? 0 : excludeUpTo.hashCode());
 		result = prime * result + (includeClosed ? 1231 : 1237);
+		result = prime * result + ((resourceID == null) ? 0 : resourceID.hashCode());
+		result = prime * result + ((resourceType == null) ? 0 : resourceType.hashCode());
 		result = prime * result + (sortAscending ? 1231 : 1237);
 		return result;
 	}
@@ -81,6 +111,20 @@ public class GetRequestsParams {
 		if (includeClosed != other.includeClosed) {
 			return false;
 		}
+		if (resourceID == null) {
+			if (other.resourceID != null) {
+				return false;
+			}
+		} else if (!resourceID.equals(other.resourceID)) {
+			return false;
+		}
+		if (resourceType == null) {
+			if (other.resourceType != null) {
+				return false;
+			}
+		} else if (!resourceType.equals(other.resourceType)) {
+			return false;
+		}
 		if (sortAscending != other.sortAscending) {
 			return false;
 		}
@@ -103,6 +147,8 @@ public class GetRequestsParams {
 		private boolean includeClosed = false;
 		private boolean sortAscending = true;
 		private Optional<Instant> excludeUpTo = Optional.empty();
+		private Optional<ResourceType> resourceType = Optional.empty();
+		private Optional<ResourceID> resourceID = Optional.empty();
 		
 		private Builder() {}
 		
@@ -147,11 +193,24 @@ public class GetRequestsParams {
 			return this;
 		}
 		
+		/** Set a resource ID that limits the list of requests to include only requests
+		 * that contain that resource ID.
+		 * @param type the type of the resource.
+		 * @param id the resource ID.
+		 * @return this builder.
+		 */
+		public Builder withResource(final ResourceType type, final ResourceID id) {
+			this.resourceType = Optional.of(requireNonNull(type, "type"));
+			this.resourceID = Optional.of(requireNonNull(id, "id"));
+			return this;
+		}
+		
 		/** Build the {@link GetRequestsParams}.
 		 * @return the parameters.
 		 */
 		public GetRequestsParams build() {
-			return new GetRequestsParams(includeClosed, sortAscending, excludeUpTo);
+			return new GetRequestsParams(includeClosed, sortAscending, excludeUpTo,
+					resourceType, resourceID);
 		}
 	}
 }

--- a/src/us/kbase/groups/core/request/GroupRequest.java
+++ b/src/us/kbase/groups/core/request/GroupRequest.java
@@ -340,6 +340,7 @@ public class GroupRequest {
 			return this;
 		}
 		
+		//TODO CODE withResourcetype and withResource should be one method
 		/** Set the type of the resource that is the target of this request.
 		 * @param resourceType the resource type.
 		 * @return this builder.

--- a/src/us/kbase/groups/service/api/GroupsAPI.java
+++ b/src/us/kbase/groups/service/api/GroupsAPI.java
@@ -291,7 +291,7 @@ public class GroupsAPI {
 			@QueryParam(Fields.GET_REQUESTS_SORT_ORDER) final String order)
 			throws InvalidTokenException, NoSuchGroupException, UnauthorizedException,
 				AuthenticationException, MissingParameterException, IllegalParameterException,
-				GroupsStorageException {
+				GroupsStorageException, NoSuchResourceTypeException {
 		return APICommon.toGroupRequestJSON(groups.getRequestsForGroup(
 				getToken(token, true), new GroupID(groupID),
 				getRequestsParams(excludeUpTo, closed, order, closed == null)));

--- a/src/us/kbase/groups/service/api/RequestAPI.java
+++ b/src/us/kbase/groups/service/api/RequestAPI.java
@@ -36,6 +36,7 @@ import us.kbase.groups.core.exceptions.MissingParameterException;
 import us.kbase.groups.core.exceptions.NoSuchGroupException;
 import us.kbase.groups.core.exceptions.NoSuchRequestException;
 import us.kbase.groups.core.exceptions.NoSuchResourceException;
+import us.kbase.groups.core.exceptions.NoSuchResourceTypeException;
 import us.kbase.groups.core.exceptions.NoTokenProvidedException;
 import us.kbase.groups.core.exceptions.ResourceExistsException;
 import us.kbase.groups.core.exceptions.ResourceHandlerException;
@@ -110,7 +111,7 @@ public class RequestAPI {
 			@QueryParam(Fields.GET_REQUESTS_INCLUDE_CLOSED) final String closed,
 			@QueryParam(Fields.GET_REQUESTS_SORT_ORDER) final String order)
 			throws InvalidTokenException, AuthenticationException, GroupsStorageException,
-			IllegalParameterException {
+			IllegalParameterException, NoSuchResourceTypeException {
 		return toGroupRequestJSON(groups.getRequestsForRequester(getToken(token, true),
 				APICommon.getRequestsParams(excludeUpTo, closed, order, closed == null)));
 	}
@@ -124,7 +125,7 @@ public class RequestAPI {
 			@QueryParam(Fields.GET_REQUESTS_INCLUDE_CLOSED) final String closed,
 			@QueryParam(Fields.GET_REQUESTS_SORT_ORDER) final String order)
 			throws InvalidTokenException, AuthenticationException, GroupsStorageException,
-				IllegalParameterException, ResourceHandlerException {
+				IllegalParameterException, ResourceHandlerException, NoSuchResourceTypeException {
 		return toGroupRequestJSON(groups.getRequestsForTarget(getToken(token, true),
 				APICommon.getRequestsParams(excludeUpTo, closed, order, closed == null)));
 	}
@@ -138,7 +139,8 @@ public class RequestAPI {
 			@QueryParam(Fields.GET_REQUESTS_INCLUDE_CLOSED) final String closed,
 			@QueryParam(Fields.GET_REQUESTS_SORT_ORDER) final String order)
 			throws InvalidTokenException, NoTokenProvidedException, AuthenticationException,
-					IllegalParameterException, GroupsStorageException {
+					IllegalParameterException, GroupsStorageException,
+					NoSuchResourceTypeException {
 		return toGroupRequestJSON(groups.getRequestsForGroups(getToken(token, true),
 				APICommon.getRequestsParams(excludeUpTo, closed, order, closed == null)));
 	}

--- a/src/us/kbase/test/groups/core/GetRequestParamsTest.java
+++ b/src/us/kbase/test/groups/core/GetRequestParamsTest.java
@@ -2,6 +2,7 @@ package us.kbase.test.groups.core;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static us.kbase.test.groups.TestCommon.inst;
 
 import java.util.Optional;
@@ -10,6 +11,9 @@ import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.groups.core.GetRequestsParams;
+import us.kbase.groups.core.resource.ResourceID;
+import us.kbase.groups.core.resource.ResourceType;
+import us.kbase.test.groups.TestCommon;
 
 public class GetRequestParamsTest {
 
@@ -25,6 +29,8 @@ public class GetRequestParamsTest {
 		assertThat("incorrect exclude", p.getExcludeUpTo(), is(Optional.empty()));
 		assertThat("incorrect closed", p.isIncludeClosed(), is(false));
 		assertThat("incorrect sort", p.isSortAscending(), is(true));
+		assertThat("incorrect type", p.getResourceType(), is(Optional.empty()));
+		assertThat("incorrect type", p.getResourceID(), is(Optional.empty()));
 	}
 	
 	@Test
@@ -38,6 +44,8 @@ public class GetRequestParamsTest {
 		assertThat("incorrect exclude", p.getExcludeUpTo(), is(Optional.empty()));
 		assertThat("incorrect closed", p.isIncludeClosed(), is(false));
 		assertThat("incorrect sort", p.isSortAscending(), is(true));
+		assertThat("incorrect type", p.getResourceType(), is(Optional.empty()));
+		assertThat("incorrect type", p.getResourceID(), is(Optional.empty()));
 	}
 	
 	@Test
@@ -51,6 +59,8 @@ public class GetRequestParamsTest {
 		assertThat("incorrect exclude", p.getExcludeUpTo(), is(Optional.empty()));
 		assertThat("incorrect closed", p.isIncludeClosed(), is(false));
 		assertThat("incorrect sort", p.isSortAscending(), is(true));
+		assertThat("incorrect type", p.getResourceType(), is(Optional.empty()));
+		assertThat("incorrect type", p.getResourceID(), is(Optional.empty()));
 	}
 	
 	@Test
@@ -59,11 +69,32 @@ public class GetRequestParamsTest {
 				.withNullableExcludeUpTo(inst(10000))
 				.withNullableIncludeClosed(true)
 				.withNullableSortAscending(false)
+				.withResource(new ResourceType("t"), new ResourceID("id"))
 				.build();
 		
 		assertThat("incorrect exclude", p.getExcludeUpTo(), is(Optional.of(inst(10000))));
 		assertThat("incorrect closed", p.isIncludeClosed(), is(true));
 		assertThat("incorrect sort", p.isSortAscending(), is(false));
+		assertThat("incorrect type", p.getResourceType(), is(Optional.of(new ResourceType("t"))));
+		assertThat("incorrect type", p.getResourceID(), is(Optional.of(new ResourceID("id"))));
+	}
+	
+	@Test
+	public void withResourceFailNulls() throws Exception {
+		withResourceFail(null, new ResourceID("i"), new NullPointerException("type"));
+		withResourceFail(new ResourceType("t"), null, new NullPointerException("id"));
+	}
+	
+	private void withResourceFail(
+			final ResourceType t,
+			final ResourceID i,
+			final Exception expected) {
+		try {
+			GetRequestsParams.getBuilder().withResource(t, i);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
 	}
 	
 }


### PR DESCRIPTION
Limit parameter lists to those with the specified resource

Also fix some urls in release notes

TODO:
check the resource type is valid in Groups.java
Implement in MongoStorage (will need new indexes)
Add to 4 endpoints query parameters