### PR TITLE
Don't allow independently setting resource & type in request

### DIFF
--- a/src/us/kbase/groups/core/Groups.java
+++ b/src/us/kbase/groups/core/Groups.java
@@ -640,8 +640,7 @@ public class Groups {
 				CreateModAndExpireTimes.getBuilder(
 						now, now.plus(REQUEST_EXPIRE_TIME)).build())
 				.withType(type)
-				.withResourceType(resourceType)
-				.withResource(resource)
+				.withResource(resourceType, resource)
 				.build();
 		storage.storeRequest(request);
 		notifications.notify(notifyTargets, request);

--- a/src/us/kbase/groups/core/request/GroupRequest.java
+++ b/src/us/kbase/groups/core/request/GroupRequest.java
@@ -1,6 +1,7 @@
 package us.kbase.groups.core.request;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -340,24 +341,14 @@ public class GroupRequest {
 			return this;
 		}
 		
-		//TODO CODE withResourcetype and withResource should be one method
-		/** Set the type of the resource that is the target of this request.
-		 * @param resourceType the resource type.
-		 * @return this builder.
-		 */
-		public Builder withResourceType(final ResourceType resourceType) {
-			checkNotNull(resourceType, "resourceType");
-			this.resourceType = resourceType;
-			return this;
-		}
-		
 		/** Set the resource that is the target of this request.
+		 * @param the type of the resource.
 		 * @param resource the resource.
 		 * @return this builder.
 		 */
-		public Builder withResource(final ResourceDescriptor resource) {
-			checkNotNull(resource, "resource");
-			this.resource = resource;
+		public Builder withResource(final ResourceType type, final ResourceDescriptor resource) {
+			this.resourceType = requireNonNull(type, "type");
+			this.resource = requireNonNull(resource, "resource");
 			return this;
 		}
 		

--- a/src/us/kbase/groups/storage/mongo/MongoGroupsStorage.java
+++ b/src/us/kbase/groups/storage/mongo/MongoGroupsStorage.java
@@ -1350,12 +1350,14 @@ public class MongoGroupsStorage implements GroupsStorage {
 									.toInstant())
 							.build())
 					.withType(RequestType.valueOf(req.getString(Fields.REQUEST_TYPE)))
-					.withResourceType(new ResourceType(
-							req.getString(Fields.REQUEST_RESOURCE_TYPE)))
-					.withResource(new ResourceDescriptor(
-							new ResourceAdministrativeID(
-									req.getString(Fields.REQUEST_RESOURCE_ADMINISTRATIVE_ID)),
-							new ResourceID(req.getString(Fields.REQUEST_RESOURCE_ID))))
+					.withResource(
+							new ResourceType(
+									req.getString(Fields.REQUEST_RESOURCE_TYPE)),
+							new ResourceDescriptor(
+									new ResourceAdministrativeID(
+											req.getString(
+													Fields.REQUEST_RESOURCE_ADMINISTRATIVE_ID)),
+									new ResourceID(req.getString(Fields.REQUEST_RESOURCE_ID))))
 					.withStatus(GroupRequestStatus.from(
 							GroupRequestStatusType.valueOf(req.getString(Fields.REQUEST_STATUS)),
 							closedBy == null ? null : new UserName(closedBy),

--- a/src/us/kbase/test/groups/core/GroupsTest.java
+++ b/src/us/kbase/test/groups/core/GroupsTest.java
@@ -1945,7 +1945,7 @@ public class GroupsTest {
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(1209610000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("foo")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("foo")))
 				.build());
 		
 		verify(mocks.notifs).notify(
@@ -1956,7 +1956,8 @@ public class GroupsTest {
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(1209610000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("foo")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("foo")))
 						.build()
 				);
 		
@@ -1966,7 +1967,7 @@ public class GroupsTest {
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(1209610000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("foo")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("foo")))
 				.build()
 				));
 	}
@@ -2096,7 +2097,8 @@ public class GroupsTest {
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(1209610000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("foo")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("foo")))
 						.build()
 				);
 		
@@ -2154,8 +2156,8 @@ public class GroupsTest {
 	public void getRequestResourceCreatorOpen() throws Exception {
 		getRequest(
 				new UserName("user"),
-				b -> b.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("78"))),
+				b -> b.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("78"))),
 				set(GroupRequestUserAction.CANCEL));
 	}
 	
@@ -2163,8 +2165,8 @@ public class GroupsTest {
 	public void getRequestResourceCreatorClosed() throws Exception {
 		getRequest(
 				new UserName("user"),
-				b -> b.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("78")))
+				b -> b.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("78")))
 						.withStatus(GroupRequestStatus.canceled()),
 				set());
 	}
@@ -2173,8 +2175,8 @@ public class GroupsTest {
 	public void getRequestResourceAdminOpen() throws Exception {
 		getRequest(
 				new UserName("own"),
-				b -> b.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("78"))),
+				b -> b.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("78"))),
 				set(GroupRequestUserAction.ACCEPT, GroupRequestUserAction.DENY));
 	}
 	
@@ -2182,8 +2184,8 @@ public class GroupsTest {
 	public void getRequestResourceAdminClosed() throws Exception {
 		getRequest(
 				new UserName("admin"),
-				b -> b.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("78")))
+				b -> b.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("78")))
 						.withStatus(GroupRequestStatus.expired()),
 				set());
 	}
@@ -2193,7 +2195,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("user"),
 				b -> b.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite"))),
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite"))),
 				set(GroupRequestUserAction.CANCEL));
 	}
 	
@@ -2202,7 +2205,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("user"),
 				b -> b.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite")))
 						.withStatus(GroupRequestStatus.canceled()),
 				set());
 	}
@@ -2212,7 +2216,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("invite"),
 				b -> b.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite"))),
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite"))),
 				set(GroupRequestUserAction.ACCEPT, GroupRequestUserAction.DENY));
 	}
 	
@@ -2221,7 +2226,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("invite"),
 				b -> b.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite")))
 						.withStatus(GroupRequestStatus.expired()),
 				set());
 	}
@@ -2231,8 +2237,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("user"),
 				b -> b.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("87"))),
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("87"))),
 				set(GroupRequestUserAction.CANCEL));
 	}
 	
@@ -2241,8 +2247,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("user"),
 				b -> b.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("87")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("87")))
 						.withStatus(GroupRequestStatus.canceled()),
 				set());
 	}
@@ -2252,8 +2258,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("wsadmin"),
 				b -> b.withType(RequestType.INVITE)
-					.withResourceType(new ResourceType("workspace"))
-					.withResource(new ResourceDescriptor(new ResourceID("87"))),
+					.withResource(new ResourceType("workspace"),
+							new ResourceDescriptor(new ResourceID("87"))),
 				set(GroupRequestUserAction.ACCEPT, GroupRequestUserAction.DENY));
 	}
 	
@@ -2262,8 +2268,8 @@ public class GroupsTest {
 		getRequest(
 				new UserName("wsadmin"),
 				b -> b.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("87")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("87")))
 						.withStatus(GroupRequestStatus.expired()),
 				set());
 	}
@@ -2350,7 +2356,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("invite")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("invite")))
 				.withStatus(GroupRequestStatus.expired())
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid")))
@@ -2395,7 +2402,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("invite")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("invite")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2418,8 +2426,8 @@ public class GroupsTest {
 				new RequestID(id), new GroupID("gid"), new UserName("requester"),
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("67")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("67")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2443,8 +2451,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("96")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("96")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2471,8 +2479,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("96")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("96")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2499,9 +2507,9 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-						new ResourceID("mod.meth")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+								new ResourceID("mod.meth")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2531,7 +2539,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(new ResourceDescriptor(new ResourceID("bad*user")))
+				.withResource(GroupRequest.USER_TYPE,
+						new ResourceDescriptor(new ResourceID("bad*user")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2558,9 +2567,9 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("caterlawgmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-						new ResourceID("mod.meth")))
+				.withResource(new ResourceType("caterlawgmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+								new ResourceID("mod.meth")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2593,8 +2602,8 @@ public class GroupsTest {
 		getGroupForRequest(
 				new UserName("target"),
 				b -> b.withType(RequestType.INVITE)
-					.withResourceType(new ResourceType("user"))
-					.withResource(new ResourceDescriptor(new ResourceID("target"))));
+					.withResource(new ResourceType("user"),
+							new ResourceDescriptor(new ResourceID("target"))));
 	}
 	
 	@Test
@@ -2602,8 +2611,8 @@ public class GroupsTest {
 		getGroupForRequest(
 				new UserName("wsadmin"),
 				b -> b.withType(RequestType.INVITE)
-					.withResourceType(new ResourceType("workspace"))
-					.withResource(new ResourceDescriptor(new ResourceID("87"))));
+					.withResource(new ResourceType("workspace"),
+							new ResourceDescriptor(new ResourceID("87"))));
 	}
 	
 	private void getGroupForRequest(
@@ -2714,7 +2723,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("invite")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("invite")))
 				.withStatus(GroupRequestStatus.expired())
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid")))
@@ -2759,7 +2769,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("invite")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("invite")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2806,7 +2817,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(new ResourceDescriptor(new ResourceID("target")))
+				.withResource(GroupRequest.USER_TYPE,
+						new ResourceDescriptor(new ResourceID("target")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
@@ -2830,8 +2842,8 @@ public class GroupsTest {
 				new RequestID(id), new GroupID("gid"), new UserName("requester"),
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("67")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("67")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2855,8 +2867,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("96")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("96")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2883,8 +2895,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("96")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("96")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2911,8 +2923,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("mod"),
 						new ResourceID("mod.meth")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
@@ -2943,7 +2955,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(new ResourceDescriptor(new ResourceID("bad*user")))
+				.withResource(GroupRequest.USER_TYPE,
+						new ResourceDescriptor(new ResourceID("bad*user")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -2971,9 +2984,9 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("caterlawgmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-						new ResourceID("mod.meth")))
+				.withResource(new ResourceType("caterlawgmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+								new ResourceID("mod.meth")))
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -3048,8 +3061,8 @@ public class GroupsTest {
 										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("workspace"))
-								.withResource(new ResourceDescriptor(new ResourceID("someid")))
+								.withResource(new ResourceType("workspace"),
+										new ResourceDescriptor(new ResourceID("someid")))
 								.build(),
 						GroupRequest.getBuilder(
 								new RequestID(id2), new GroupID("gid2"), new UserName("user"),
@@ -3057,8 +3070,8 @@ public class GroupsTest {
 										Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
-								.withResourceType(new ResourceType("workspace"))
-								.withResource(new ResourceDescriptor(new ResourceID("someid")))
+								.withResource(new ResourceType("workspace"),
+										new ResourceDescriptor(new ResourceID("someid")))
 								.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
 								.build()
 						));
@@ -3076,8 +3089,8 @@ public class GroupsTest {
 										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("workspace"))
-								.withResource(new ResourceDescriptor(new ResourceID("someid")))
+								.withResource(new ResourceType("workspace"),
+										new ResourceDescriptor(new ResourceID("someid")))
 								.build(),
 						GroupRequest.getBuilder(
 								new RequestID(id2), new GroupID("gid2"), new UserName("user"),
@@ -3085,11 +3098,11 @@ public class GroupsTest {
 										Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("someid")))
-								.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
-								.build()
-						)));
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("someid")))
+						.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
+						.build()
+				)));
 	}
 	
 	@Test
@@ -3180,7 +3193,8 @@ public class GroupsTest {
 										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 								.build())
 								.withType(RequestType.INVITE)
-								.withResource(ResourceDescriptor.from(new UserName("target")))
+								.withResource(GroupRequest.USER_TYPE,
+										ResourceDescriptor.from(new UserName("target")))
 								.build(),
 						GroupRequest.getBuilder(
 								new RequestID(id2), new GroupID("gid"), new UserName("user"),
@@ -3189,8 +3203,8 @@ public class GroupsTest {
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("workspace"))
-								.withResource(new ResourceDescriptor(new ResourceID("24")))
+								.withResource(new ResourceType("workspace"),
+										new ResourceDescriptor(new ResourceID("24")))
 								.withStatus(GroupRequestStatus.accepted(new UserName("wsadmin")))
 								.build(),
 						GroupRequest.getBuilder(
@@ -3200,10 +3214,10 @@ public class GroupsTest {
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("catalogmethod"))
-								.withResource(new ResourceDescriptor(
-										new ResourceAdministrativeID("mod2"),
-										new ResourceID("mod2.meth")))
+								.withResource(new ResourceType("catalogmethod"),
+										new ResourceDescriptor(
+												new ResourceAdministrativeID("mod2"),
+												new ResourceID("mod2.meth")))
 								.withStatus(GroupRequestStatus.canceled())
 								.build()
 						));
@@ -3220,7 +3234,8 @@ public class GroupsTest {
 										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResource(ResourceDescriptor.from(new UserName("target")))
+								.withResource(GroupRequest.USER_TYPE,
+										ResourceDescriptor.from(new UserName("target")))
 								.build(),
 						GroupRequest.getBuilder(
 								new RequestID(id2), new GroupID("gid"), new UserName("user"),
@@ -3229,8 +3244,8 @@ public class GroupsTest {
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("workspace"))
-								.withResource(new ResourceDescriptor(new ResourceID("24")))
+								.withResource(new ResourceType("workspace"),
+										new ResourceDescriptor(new ResourceID("24")))
 								.withStatus(GroupRequestStatus.accepted(new UserName("wsadmin")))
 								.build(),
 						GroupRequest.getBuilder(
@@ -3240,10 +3255,10 @@ public class GroupsTest {
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("catalogmethod"))
-								.withResource(new ResourceDescriptor(
-								new ResourceAdministrativeID("mod2"),
-								new ResourceID("mod2.meth")))
+								.withResource(new ResourceType("catalogmethod"),
+										new ResourceDescriptor(
+												new ResourceAdministrativeID("mod2"),
+												new ResourceID("mod2.meth")))
 								.withStatus(GroupRequestStatus.canceled())
 								.build()
 						)));
@@ -3328,10 +3343,10 @@ public class GroupsTest {
 								CreateModAndExpireTimes.getBuilder(
 										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 										.build())
-								.withResourceType(new ResourceType("catalogmethod"))
-								.withResource(new ResourceDescriptor(
-										new ResourceAdministrativeID("mod"),
-										new ResourceID("mod.m")))
+								.withResource(new ResourceType("catalogmethod"),
+										new ResourceDescriptor(
+												new ResourceAdministrativeID("mod"),
+												new ResourceID("mod.m")))
 								.build(),
 						GroupRequest.getBuilder(
 								new RequestID(id2), new GroupID("gid"), new UserName("user"),
@@ -3339,10 +3354,10 @@ public class GroupsTest {
 										Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
-								.withResourceType(new ResourceType("catalogmethod"))
-								.withResource(new ResourceDescriptor(
-										new ResourceAdministrativeID("mod"),
-										new ResourceID("mod.m")))
+								.withResource(new ResourceType("catalogmethod"),
+										new ResourceDescriptor(
+												new ResourceAdministrativeID("mod"),
+												new ResourceID("mod.m")))
 								.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
 								.build()
 						));
@@ -3359,10 +3374,10 @@ public class GroupsTest {
 								CreateModAndExpireTimes.getBuilder(
 										Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 										.build())
-								.withResourceType(new ResourceType("catalogmethod"))
-								.withResource(new ResourceDescriptor(
-										new ResourceAdministrativeID("mod"),
-										new ResourceID("mod.m")))
+								.withResource(new ResourceType("catalogmethod"),
+										new ResourceDescriptor(
+												new ResourceAdministrativeID("mod"),
+												new ResourceID("mod.m")))
 								.build(),
 						GroupRequest.getBuilder(
 								new RequestID(id2), new GroupID("gid"), new UserName("user"),
@@ -3370,10 +3385,10 @@ public class GroupsTest {
 										Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
-								.withResourceType(new ResourceType("catalogmethod"))
-								.withResource(new ResourceDescriptor(
-										new ResourceAdministrativeID("mod"),
-										new ResourceID("mod.m")))
+								.withResource(new ResourceType("catalogmethod"),
+										new ResourceDescriptor(
+												new ResourceAdministrativeID("mod"),
+												new ResourceID("mod.m")))
 								.withStatus(GroupRequestStatus.accepted(new UserName("admin")))
 								.build()
 				)));
@@ -3589,7 +3604,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite")))
 						.build(),
 				GroupRequest.getBuilder(
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
@@ -3598,7 +3614,8 @@ public class GroupsTest {
 								.withModificationTime(Instant.ofEpochMilli(15000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite")))
 						.withStatus(GroupRequestStatus.canceled())
 						.build());
 		when(mocks.clock.instant()).thenReturn(Instant.ofEpochMilli(15000));
@@ -3616,7 +3633,8 @@ public class GroupsTest {
 						.withModificationTime(Instant.ofEpochMilli(15000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("invite")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("invite")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build()));
 	}
@@ -3656,7 +3674,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite")))
 						.build());
 		
 		failCancelRequest(mocks.groups, new Token("token"), new RequestID(id),
@@ -3675,7 +3694,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("invite")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("invite")))
 						.withStatus(GroupRequestStatus.accepted(new UserName("someguy")))
 						.build());
 		
@@ -3709,16 +3729,16 @@ public class GroupsTest {
 	@Test
 	public void denyRequestAdminWhitespaceReasonRequestResource() throws Exception {
 		denyRequestAdmin("    \t    ", "admin",
-				b -> b.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("86"))));
+				b -> b.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("86"))));
 	}
 	
 	@Test
 	public void denyRequestAdminReasonInviteResource() throws Exception {
 		denyRequestAdmin(" reason  ", "wsadmin",
 				b -> b.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("86"))));
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("86"))));
 	}
 	
 	private void denyRequestAdmin(
@@ -3796,7 +3816,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.build(),
 				GroupRequest.getBuilder(
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
@@ -3805,7 +3826,8 @@ public class GroupsTest {
 								.withModificationTime(Instant.ofEpochMilli(15000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.withStatus(GroupRequestStatus.denied(new UserName("target"), "reason"))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
@@ -3832,7 +3854,8 @@ public class GroupsTest {
 								.withModificationTime(Instant.ofEpochMilli(15000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.withStatus(GroupRequestStatus.denied(new UserName("target"), "reason"))
 						.build());
 		
@@ -3843,7 +3866,8 @@ public class GroupsTest {
 						.withModificationTime(Instant.ofEpochMilli(15000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("target")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("target")))
 				.withStatus(GroupRequestStatus.denied(new UserName("target"), "reason"))
 				.build()));
 	}
@@ -3881,7 +3905,8 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("invite")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("invite")))
 				.withStatus(GroupRequestStatus.expired())
 				.build());
 		when(mocks.storage.getGroup(new GroupID("gid")))
@@ -3904,7 +3929,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -3924,17 +3950,17 @@ public class GroupsTest {
 	
 	@Test
 	public void denyRequestFailNotAdminRequestResource() throws Exception {
-		denyRequestFailNotAdmin(b -> b.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("foo"),
+		denyRequestFailNotAdmin(b -> b.withResource(new ResourceType("catalogmethod"),
+				new ResourceDescriptor(new ResourceAdministrativeID("foo"),
 						new ResourceID("foo.bar"))));
 	}
 	
 	@Test
 	public void denyRequestFailNotAdminInviteResource() throws Exception {
 		denyRequestFailNotAdmin(b -> b.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("foo"),
-						new ResourceID("foo.baz"))));
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("foo"),
+								new ResourceID("foo.baz"))));
 	}
 	
 	private void denyRequestFailNotAdmin(
@@ -3978,7 +4004,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.withStatus(GroupRequestStatus.canceled())
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
@@ -4004,8 +4031,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("56")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("56")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4033,9 +4060,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-								new ResourceID("mod.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+										new ResourceID("mod.meth")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4066,7 +4093,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(new ResourceDescriptor(new ResourceID("bad*user")))
+						.withResource(GroupRequest.USER_TYPE,
+								new ResourceDescriptor(new ResourceID("bad*user")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4094,9 +4122,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("caterlogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-								new ResourceID("mod.meth")))
+						.withResource(new ResourceType("caterlogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+										new ResourceID("mod.meth")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4149,7 +4177,8 @@ public class GroupsTest {
 		acceptRequest(mocks, new UserName("target"),
 				set(new UserName("own"), new UserName("admin"), new UserName("a3")),
 				b -> b.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target"))));
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target"))));
 
 		final GroupUser u = GroupUser.getBuilder(new UserName("target"), inst(12000)).build();
 		verify(mocks.storage).addMember(new GroupID("gid"), u, inst(12000));
@@ -4164,8 +4193,8 @@ public class GroupsTest {
 		acceptRequest(mocks, new UserName("admin"),
 				set(new UserName("u1"), new UserName("u2"), new UserName("own"),
 						new UserName("a3"), new UserName("u3")),
-				b -> b.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("56"))));
+				b -> b.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("56"))));
 
 		verify(mocks.storage).addResource(
 				new GroupID("gid"),
@@ -4186,9 +4215,9 @@ public class GroupsTest {
 				set(new UserName("admin"), new UserName("u4"), new UserName("own"),
 						new UserName("a3"), new UserName("u1"), new UserName("u3")),
 				b -> b.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-								new ResourceID("mod.n"))));
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+										new ResourceID("mod.n"))));
 
 		verify(mocks.storage).addResource(
 				new GroupID("gid"),
@@ -4282,7 +4311,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4302,15 +4332,15 @@ public class GroupsTest {
 	
 	@Test
 	public void acceptRequestResourceFailNotAdmin() throws Exception {
-		acceptRequestFailNotAdmin(b -> b.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("34"))));
+		acceptRequestFailNotAdmin(b -> b.withResource(new ResourceType("workspace"),
+				new ResourceDescriptor(new ResourceID("34"))));
 	}
 	
 	@Test
 	public void acceptRequestResourceFailNotResourceAdmin() throws Exception {
 		acceptRequestFailNotAdmin(b -> b.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("55"))));
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("55"))));
 	}
 	
 	private void acceptRequestFailNotAdmin(
@@ -4352,7 +4382,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.withStatus(GroupRequestStatus.expired())
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
@@ -4409,7 +4440,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(ResourceDescriptor.from(new UserName("target")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("target")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4439,8 +4471,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("56")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("56")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4469,9 +4501,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("md"),
-								new ResourceID("md.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("md"),
+										new ResourceID("md.meth")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4499,8 +4531,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("56")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("56")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4536,8 +4568,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("4")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("4")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4568,9 +4600,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("md"),
-								new ResourceID("md.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("md"),
+										new ResourceID("md.meth")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4600,7 +4632,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResource(new ResourceDescriptor(new ResourceID("bad*user")))
+						.withResource(GroupRequest.USER_TYPE,
+								new ResourceDescriptor(new ResourceID("bad*user")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4629,8 +4662,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("worksperce"))
-						.withResource(new ResourceDescriptor(new ResourceID("4")))
+						.withResource(new ResourceType("worksperce"),
+									new ResourceDescriptor(new ResourceID("4")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4659,7 +4692,8 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResource(new ResourceDescriptor(new ResourceID("bad*user")))
+						.withResource(GroupRequest.USER_TYPE,
+								new ResourceDescriptor(new ResourceID("bad*user")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -4689,9 +4723,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("certerlergmerthod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("md"),
-								new ResourceID("md.meth")))
+						.withResource(new ResourceType("certerlergmerthod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("md"),
+										new ResourceID("md.meth")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -5096,9 +5130,9 @@ public class GroupsTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(20000), Instant.ofEpochMilli(1209620000))
 						.build())
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-						new ResourceID("mod.meth")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+								new ResourceID("mod.meth")))
 				.build());
 		
 		verify(mocks.notifs).notify(
@@ -5108,9 +5142,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(20000), Instant.ofEpochMilli(1209620000))
 								.build())
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-								new ResourceID("mod.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+										new ResourceID("mod.meth")))
 						.build()
 				);
 		
@@ -5120,9 +5154,9 @@ public class GroupsTest {
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(20000), Instant.ofEpochMilli(1209620000))
 								.build())
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-								new ResourceID("mod.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+										new ResourceID("mod.meth")))
 						.build())));
 	}
 	
@@ -5157,8 +5191,8 @@ public class GroupsTest {
 						Instant.ofEpochMilli(20000), Instant.ofEpochMilli(1209620000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("34")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("34")))
 				.build());
 		
 		verify(mocks.notifs).notify(
@@ -5169,8 +5203,8 @@ public class GroupsTest {
 								Instant.ofEpochMilli(20000), Instant.ofEpochMilli(1209620000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("34")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("34")))
 						.build()
 				);
 		
@@ -5181,8 +5215,8 @@ public class GroupsTest {
 								Instant.ofEpochMilli(20000), Instant.ofEpochMilli(1209620000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("34")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("34")))
 						.build())));
 	}
 	
@@ -5568,9 +5602,9 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-								new ResourceID("m.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("m"),
+										new ResourceID("m.meth")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -5608,8 +5642,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("43")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("43")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid")))
 				.thenThrow(new NoSuchGroupException("gid"));
@@ -5631,8 +5665,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("43")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("43")))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(
 				new GroupID("gid"), new GroupName("name"), toGUser("own"),
@@ -5651,7 +5685,8 @@ public class GroupsTest {
 		setReadPermissionResourceFail(
 				UUID.randomUUID(),
 				b -> b.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("workspace")),
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("2"))),
 				new UnauthorizedException(
 						"Only Request type requests allow for resource permissions changes."));
 	}
@@ -5660,7 +5695,8 @@ public class GroupsTest {
 	public void setReadPermissionResourceFailResourceType() throws Exception {
 		setReadPermissionResourceFail(
 				UUID.randomUUID(),
-				b -> b.withResourceType(new ResourceType("user")),
+				b -> b.withResource(new ResourceType("user"),
+						ResourceDescriptor.from(new UserName("u"))),
 				new UnauthorizedException("Requests with a user resource type do not allow " +
 						"for permissions changes."));
 	}
@@ -5670,7 +5706,8 @@ public class GroupsTest {
 		final UUID id = UUID.randomUUID();
 		setReadPermissionResourceFail(
 				id,
-				b -> b.withResourceType(new ResourceType("wrkspce")),
+				b -> b.withResource(new ResourceType("wrkspce"),
+						new ResourceDescriptor(new ResourceID("3"))),
 				new RuntimeException(
 						"No handler configured for resource type wrkspce in request " +
 						id.toString()));
@@ -5712,8 +5749,8 @@ public class GroupsTest {
 						new RequestID(id), new GroupID("gid"), new UserName("user"),
 						CreateModAndExpireTimes.getBuilder(
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000)).build())
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("43")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("43")))
 						.withStatus(GroupRequestStatus.denied(new UserName("d"), null))
 						.build());
 		when(mocks.storage.getGroup(new GroupID("gid"))).thenReturn(Group.getBuilder(

--- a/src/us/kbase/test/groups/core/request/GroupRequestTest.java
+++ b/src/us/kbase/test/groups/core/request/GroupRequestTest.java
@@ -70,9 +70,9 @@ public class GroupRequestTest {
 						.withModificationTime(Instant.ofEpochMilli(30000))
 				.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("module"),
-						new ResourceID("module.method")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("module"),
+								new ResourceID("module.method")))
 				.withStatus(GroupRequestStatus.denied(new UserName("immean"), "targ is junky"))
 				.build();
 		
@@ -105,9 +105,9 @@ public class GroupRequestTest {
 				CreateModAndExpireTimes.getBuilder(
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 				.build())
-				.withResourceType(new ResourceType("githubrepo"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("kbase"),
-						new ResourceID("kbase/groups")))
+				.withResource(new ResourceType("githubrepo"),
+						new ResourceDescriptor(new ResourceAdministrativeID("kbase"),
+								new ResourceID("kbase/groups")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build();
 		
@@ -205,22 +205,21 @@ public class GroupRequestTest {
 	}
 	
 	@Test
-	public void withResourceTypeFail() throws Exception {
-		try {
-			getBuilder().withResourceType(null);
-			fail("expected exception");
-		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new NullPointerException("resourceType"));
-		}
+	public void withResourceFail() throws Exception {
+		withResourceFail(null, new ResourceDescriptor(new ResourceID("i")),
+				new NullPointerException("type"));
+		withResourceFail(new ResourceType("t"), null, new NullPointerException("resource"));
 	}
 	
-	@Test
-	public void withResourceFail() throws Exception {
+	private void withResourceFail(
+			final ResourceType t,
+			final ResourceDescriptor d,
+			final Exception expected) {
 		try {
-			getBuilder().withResource(null);
+			getBuilder().withResource(t, d);
 			fail("expected exception");
 		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new NullPointerException("resource"));
+			TestCommon.assertExceptionCorrect(got, expected);
 		}
 	}
 	

--- a/src/us/kbase/test/groups/notifications/KafkaFeedsNotifierFactoryTest.java
+++ b/src/us/kbase/test/groups/notifications/KafkaFeedsNotifierFactoryTest.java
@@ -225,8 +225,8 @@ public class KafkaFeedsNotifierFactoryTest {
 				GroupRequest.getBuilder(new RequestID(UUID.randomUUID()), new GroupID("gid"),
 						new UserName("act"),
 						CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("resid")))
-				.withResourceType(new ResourceType("rtype"))
+				.withResource(new ResourceType("rtype"),
+						new ResourceDescriptor(new ResourceID("resid")))
 				.withType(RequestType.REQUEST)
 				.build());
 		
@@ -272,8 +272,8 @@ public class KafkaFeedsNotifierFactoryTest {
 				set(new UserName("foo"), new UserName("bar")),
 				GroupRequest.getBuilder(new RequestID(id), new GroupID("gid"), new UserName("act"),
 						CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("resid")))
-				.withResourceType(new ResourceType("user"))
+				.withResource(new ResourceType("user"),
+						new ResourceDescriptor(new ResourceID("resid")))
 				.withType(rtype)
 				.build());
 		
@@ -294,8 +294,8 @@ public class KafkaFeedsNotifierFactoryTest {
 		final GroupRequest r = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("i"), new UserName("n"),
 				CreateModAndExpireTimes.getBuilder(inst(1), inst(2)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("foo")))
-				.withResourceType(new ResourceType("badtype"))
+				.withResource(new ResourceType("badtype"),
+						new ResourceDescriptor(new ResourceID("foo")))
 				.build();
 		
 		notifyFail(set(new UserName("n")), r, new IllegalArgumentException(
@@ -322,8 +322,8 @@ public class KafkaFeedsNotifierFactoryTest {
 				GroupRequest.getBuilder(new RequestID(UUID.randomUUID()), new GroupID("gid"),
 						new UserName("act"),
 						CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("resid")))
-				.withResourceType(new ResourceType("rtype"))
+				.withResource(new ResourceType("rtype"),
+						new ResourceDescriptor(new ResourceID("resid")))
 				.withType(RequestType.REQUEST)
 				.build());
 		
@@ -361,8 +361,8 @@ public class KafkaFeedsNotifierFactoryTest {
 				set(new UserName("bar"), new UserName("baz")),
 				GroupRequest.getBuilder(new RequestID(id), new GroupID("id2"), new UserName("act"),
 						CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("resid2")))
-				.withResourceType(new ResourceType("user"))
+				.withResource(new ResourceType("user"),
+						new ResourceDescriptor(new ResourceID("resid2")))
 				.withType(RequestType.INVITE)
 				.build());
 		
@@ -384,8 +384,8 @@ public class KafkaFeedsNotifierFactoryTest {
 		final GroupRequest r = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("i"), new UserName("n"),
 				CreateModAndExpireTimes.getBuilder(inst(1), inst(2)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("foo")))
-				.withResourceType(new ResourceType("badtype"))
+				.withResource(new ResourceType("badtype"),
+						new ResourceDescriptor(new ResourceID("foo")))
 				.build();
 		
 		acceptFail(set(new UserName("n")), r, new IllegalArgumentException(
@@ -412,8 +412,8 @@ public class KafkaFeedsNotifierFactoryTest {
 				GroupRequest.getBuilder(new RequestID(UUID.randomUUID()), new GroupID("gid"),
 						new UserName("act"),
 						CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("resid")))
-				.withResourceType(new ResourceType("rtype"))
+				.withResource(new ResourceType("rtype"),
+						new ResourceDescriptor(new ResourceID("resid")))
 				.withType(RequestType.REQUEST)
 				.build());
 		
@@ -452,8 +452,8 @@ public class KafkaFeedsNotifierFactoryTest {
 				set(new UserName("bat"), new UserName("bang")),
 				GroupRequest.getBuilder(new RequestID(id), new GroupID("id8"), new UserName("act"),
 						CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("resid9")))
-				.withResourceType(new ResourceType("workspace"))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("resid9")))
 				.withType(RequestType.REQUEST)
 				.build());
 		
@@ -474,8 +474,8 @@ public class KafkaFeedsNotifierFactoryTest {
 		final GroupRequest r = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("i"), new UserName("n"),
 				CreateModAndExpireTimes.getBuilder(inst(1), inst(2)).build())
-				.withResource(new ResourceDescriptor(new ResourceID("foo")))
-				.withResourceType(new ResourceType("badtype"))
+				.withResource(new ResourceType("badtype"),
+						new ResourceDescriptor(new ResourceID("foo")))
 				.build();
 		
 		denyFail(set(new UserName("n")), r, new IllegalArgumentException(
@@ -532,8 +532,8 @@ public class KafkaFeedsNotifierFactoryTest {
 					GroupRequest.getBuilder(new RequestID(id), new GroupID("id8"),
 							new UserName("act"),
 							CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-					.withResource(new ResourceDescriptor(new ResourceID("resid9")))
-					.withResourceType(new ResourceType("workspace"))
+					.withResource(new ResourceType("workspace"),
+							new ResourceDescriptor(new ResourceID("resid9")))
 					.withType(RequestType.REQUEST)
 					.build());
 			fail("expected exception");
@@ -577,8 +577,8 @@ public class KafkaFeedsNotifierFactoryTest {
 					GroupRequest.getBuilder(new RequestID(id), new GroupID("id8"),
 							new UserName("act"),
 							CreateModAndExpireTimes.getBuilder(inst(10000), inst(30000)).build())
-					.withResource(new ResourceDescriptor(new ResourceID("resid9")))
-					.withResourceType(new ResourceType("catalogmethod"))
+					.withResource(new ResourceType("catalogmethod"),
+							new ResourceDescriptor(new ResourceID("resid9")))
 					.withType(RequestType.INVITE)
 					.build());
 			fail("expected exception");

--- a/src/us/kbase/test/groups/service/api/APICommonTest.java
+++ b/src/us/kbase/test/groups/service/api/APICommonTest.java
@@ -86,8 +86,7 @@ public class APICommonTest {
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("n")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("n")))
 				.build();
 		
 		assertThat("incorrect request", APICommon.toGroupRequestJSON(r), is(MapBuilder.newHashMap()
@@ -114,8 +113,7 @@ public class APICommonTest {
 						.withModificationTime(Instant.ofEpochMilli(25000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("inv")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("inv")))
 				.withStatus(GroupRequestStatus.denied(new UserName("den"), "r"))
 				.build();
 		
@@ -143,8 +141,8 @@ public class APICommonTest {
 						.withModificationTime(Instant.ofEpochMilli(25000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("42")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("42")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build();
 		
@@ -172,8 +170,8 @@ public class APICommonTest {
 						.withModificationTime(Instant.ofEpochMilli(25000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceID("mod.meth")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceID("mod.meth")))
 				.withStatus(GroupRequestStatus.expired())
 				.build();
 		
@@ -201,8 +199,8 @@ public class APICommonTest {
 						.withModificationTime(Instant.ofEpochMilli(25000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceID("mod.meth")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceID("mod.meth")))
 				.withStatus(GroupRequestStatus.expired())
 				.build();
 		
@@ -239,8 +237,8 @@ public class APICommonTest {
 						Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("n1")))
+				.withResource(new ResourceType("user"),
+						ResourceDescriptor.from(new UserName("n1")))
 				.build();
 		
 		final UUID id2 = UUID.randomUUID();
@@ -251,8 +249,8 @@ public class APICommonTest {
 						.withModificationTime(Instant.ofEpochMilli(26000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("inv")))
+				.withResource(new ResourceType("user"),
+						ResourceDescriptor.from(new UserName("inv")))
 				.withStatus(GroupRequestStatus.denied(new UserName("den"), "r"))
 				.build();
 		
@@ -264,8 +262,8 @@ public class APICommonTest {
 						.withModificationTime(Instant.ofEpochMilli(27000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("42")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("42")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build();
 		

--- a/src/us/kbase/test/groups/service/api/GroupsAPITest.java
+++ b/src/us/kbase/test/groups/service/api/GroupsAPITest.java
@@ -1061,8 +1061,8 @@ public class GroupsAPITest {
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(30000))
 								.build())
 						.withType(RequestType.REQUEST)
-						.withResourceType(new ResourceType("user"))
-						.withResource(ResourceDescriptor.from(new UserName("foo")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("foo")))
 						.build());
 		
 		final Map<String, Object> ret = new GroupsAPI(g).requestGroupMembership("t", "gid");
@@ -1131,8 +1131,8 @@ public class GroupsAPITest {
 								Instant.ofEpochMilli(10000), Instant.ofEpochMilli(30000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("user"))
-						.withResource(ResourceDescriptor.from(new UserName("bar")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("bar")))
 						.build());
 		
 		final Map<String, Object> ret = new GroupsAPI(g).inviteMember("t", "gid", "bar");
@@ -1268,8 +1268,8 @@ public class GroupsAPITest {
 										.withModificationTime(Instant.ofEpochMilli(25000))
 										.build())
 								.withType(RequestType.INVITE)
-								.withResourceType(new ResourceType("user"))
-								.withResource(ResourceDescriptor.from(new UserName("baz")))
+								.withResource(GroupRequest.USER_TYPE,
+										ResourceDescriptor.from(new UserName("baz")))
 								.withStatus(GroupRequestStatus.canceled())
 								.build()
 						));
@@ -1678,8 +1678,8 @@ public class GroupsAPITest {
 									Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 									.build())
 						.withType(RequestType.REQUEST)
-						.withResourceType(new ResourceType("workspace"))
-						.withResource(new ResourceDescriptor(new ResourceID("42")))
+						.withResource(new ResourceType("workspace"),
+								new ResourceDescriptor(new ResourceID("42")))
 						.build()));
 		
 		final Map<String, Object> ret = new GroupsAPI(g)
@@ -1714,9 +1714,9 @@ public class GroupsAPITest {
 									Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 									.build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("catalogmethod"))
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("mod"),
-								new ResourceID("mod.meth")))
+						.withResource(new ResourceType("catalogmethod"),
+								new ResourceDescriptor(new ResourceAdministrativeID("mod"),
+										new ResourceID("mod.meth")))
 						.build()));
 		
 		final Map<String, Object> ret = new GroupsAPI(g)

--- a/src/us/kbase/test/groups/service/api/RequestAPITest.java
+++ b/src/us/kbase/test/groups/service/api/RequestAPITest.java
@@ -49,7 +49,6 @@ import us.kbase.groups.core.request.GroupRequestWithActions;
 import us.kbase.groups.core.request.RequestID;
 import us.kbase.groups.core.request.RequestType;
 import us.kbase.groups.core.resource.ResourceDescriptor;
-import us.kbase.groups.core.resource.ResourceType;
 import us.kbase.groups.service.api.RequestAPI;
 import us.kbase.groups.service.api.RequestAPI.DenyRequestJSON;
 import us.kbase.test.groups.MapBuilder;
@@ -79,8 +78,8 @@ public class RequestAPITest {
 							.withModificationTime(Instant.ofEpochMilli(26000))
 							.build())
 					.withType(RequestType.INVITE)
-					.withResourceType(new ResourceType("user"))
-					.withResource(ResourceDescriptor.from(new UserName("targ")))
+					.withResource(GroupRequest.USER_TYPE,
+							ResourceDescriptor.from(new UserName("targ")))
 					//TODO TEST add tests if denied state is ever visible
 					.build();
 			REQ_DENIED = GroupRequest.getBuilder(
@@ -90,8 +89,8 @@ public class RequestAPITest {
 							.withModificationTime(Instant.ofEpochMilli(27000))
 							.build())
 					.withType(RequestType.INVITE)
-					.withResourceType(new ResourceType("user"))
-					.withResource(ResourceDescriptor.from(new UserName("targ1")))
+					.withResource(GroupRequest.USER_TYPE,
+							ResourceDescriptor.from(new UserName("targ1")))
 					//TODO TEST add tests if denied state is ever visible
 					.withStatus(GroupRequestStatus.denied(new UserName("d"), "reason"))
 					.build();
@@ -682,8 +681,8 @@ public class RequestAPITest {
 								.withModificationTime(Instant.ofEpochMilli(28000))
 								.build())
 						.withType(RequestType.REQUEST)
-						.withResourceType(new ResourceType("user"))
-						.withResource(ResourceDescriptor.from(new UserName("u")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("u")))
 						.withStatus(GroupRequestStatus.canceled())
 						.build());
 		
@@ -759,8 +758,8 @@ public class RequestAPITest {
 								.withModificationTime(Instant.ofEpochMilli(28000))
 								.build())
 						.withType(RequestType.INVITE)
-						.withResourceType(new ResourceType("user"))
-						.withResource(ResourceDescriptor.from(new UserName("inv")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("inv")))
 						// normally the acceptor would be the same as the invited user,
 						// but for testing purposes it's different.
 						.withStatus(GroupRequestStatus.accepted(new UserName("inv2")))
@@ -858,8 +857,8 @@ public class RequestAPITest {
 								.withModificationTime(Instant.ofEpochMilli(28000))
 								.build())
 						.withType(RequestType.REQUEST)
-						.withResourceType(new ResourceType("user"))
-						.withResource(ResourceDescriptor.from(new UserName("u")))
+						.withResource(GroupRequest.USER_TYPE,
+								ResourceDescriptor.from(new UserName("u")))
 						// should not show up in output for now
 						.withStatus(GroupRequestStatus.denied(new UserName("d"), "testreason"))
 						.build());

--- a/src/us/kbase/test/groups/storage/mongo/MongoGroupsStorageOpsTest.java
+++ b/src/us/kbase/test/groups/storage/mongo/MongoGroupsStorageOpsTest.java
@@ -2439,9 +2439,9 @@ public class MongoGroupsStorageOpsTest {
 					.withModificationTime(Instant.ofEpochMilli(50000))
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("githubrepo"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("kbase"),
-						new ResourceID("kbase/groups")))
+				.withResource(new ResourceType("githubrepo"),
+						new ResourceDescriptor(new ResourceAdministrativeID("kbase"),
+								new ResourceID("kbase/groups")))
 				.withStatus(GroupRequestStatus.from(
 						GroupRequestStatusType.DENIED, new UserName("whee"), "jerkface"))
 				.build());
@@ -2454,9 +2454,9 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(Instant.ofEpochMilli(50000))
 						.build())
 					.withType(RequestType.INVITE)
-					.withResourceType(new ResourceType("githubrepo"))
-					.withResource(new ResourceDescriptor(new ResourceAdministrativeID("kbase"),
-							new ResourceID("kbase/groups")))
+					.withResource(new ResourceType("githubrepo"),
+							new ResourceDescriptor(new ResourceAdministrativeID("kbase"),
+									new ResourceID("kbase/groups")))
 					.withStatus(GroupRequestStatus.denied(new UserName("whee"), "jerkface"))
 					.build()));
 	}
@@ -2501,9 +2501,9 @@ public class MongoGroupsStorageOpsTest {
 						Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("yay"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("foo"),
-						new ResourceID("bar")));
+				.withResource(new ResourceType("yay"),
+						new ResourceDescriptor(new ResourceAdministrativeID("foo"),
+								new ResourceID("bar")));
 	}
 	
 	@Test
@@ -2532,7 +2532,8 @@ public class MongoGroupsStorageOpsTest {
 		// with different resource type
 		manager.storage.storeRequest(GroupRequest.getBuilder(
 				new RequestID(id3), new GroupID("foo"), new UserName("bar"), times)
-				.withResourceType(new ResourceType("foo"))
+				.withResource(new ResourceType("foo"),
+						ResourceDescriptor.from(new UserName("bar")))
 				.build());
 		
 		// with different resource
@@ -2540,8 +2541,9 @@ public class MongoGroupsStorageOpsTest {
 				new RequestID(id4), new GroupID("foo"), new UserName("bar"), times)
 				// res admin ID is not included in the char string since for a given resource ID,
 				// the admin ID is always the same
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("yay"),
-						new ResourceID("yo")))
+				.withResource(GroupRequest.USER_TYPE,
+						new ResourceDescriptor(new ResourceAdministrativeID("yay"),
+								new ResourceID("yo")))
 				.build());
 				
 		
@@ -2570,14 +2572,16 @@ public class MongoGroupsStorageOpsTest {
 		assertThat("incorrect group", manager.storage.getRequest(new RequestID(id3)), is(
 				GroupRequest.getBuilder(
 						new RequestID(id3), new GroupID("foo"), new UserName("bar"), times)
-						.withResourceType(new ResourceType("foo"))
+						.withResource(new ResourceType("foo"),
+								ResourceDescriptor.from(new UserName("bar")))
 						.build()));
 		
 		assertThat("incorrect group", manager.storage.getRequest(new RequestID(id4)), is(
 				GroupRequest.getBuilder(
 						new RequestID(id4), new GroupID("foo"), new UserName("bar"), times)
-						.withResource(new ResourceDescriptor(new ResourceAdministrativeID("yay"),
-								new ResourceID("yo")))
+						.withResource(GroupRequest.USER_TYPE,
+								new ResourceDescriptor(new ResourceAdministrativeID("yay"),
+										new ResourceID("yo")))
 						.build()));
 		
 		assertThat("incorrect group", manager.storage.getRequest(new RequestID(id5)), is(
@@ -2628,9 +2632,9 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("foo"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("aid"),
-						new ResourceID("rid")))
+				.withResource(new ResourceType("foo"),
+						new ResourceDescriptor(new ResourceAdministrativeID("aid"),
+								new ResourceID("rid")))
 				.build());
 		
 		final GroupRequest request = GroupRequest.getBuilder(
@@ -2639,11 +2643,11 @@ public class MongoGroupsStorageOpsTest {
 						Instant.ofEpochMilli(30000), Instant.ofEpochMilli(40000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("foo"))
 				// this should never actually happen. rid -> aid mapping should be immutable.
 				// however, we test here to ensure the RAID is not included in the char string.
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("aid2"),
-						new ResourceID("rid")))
+				.withResource(new ResourceType("foo"),
+						new ResourceDescriptor(new ResourceAdministrativeID("aid2"),
+								new ResourceID("rid")))
 				.build();
 		
 		failStoreRequest(request, new RequestExistsException(String.format(
@@ -2736,8 +2740,8 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(130000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("whee")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("whee")))
 				.build();
 		final GroupRequest third = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo3"), new UserName("bar"),
@@ -2745,9 +2749,9 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(140000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m1"),
-						new ResourceID("m1.n")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m1"),
+								new ResourceID("m1.n")))
 				.build();
 		final GroupRequest fourth = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo4"), new UserName("bar"),
@@ -2755,8 +2759,8 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(150000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("2")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("2")))
 				.build();
 		final GroupRequest target = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("targ"), new UserName("whee"),
@@ -2764,8 +2768,8 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("user"))
-				.withResource(new ResourceDescriptor(new ResourceID("bar")))
+				.withResource(new ResourceType("user"),
+						new ResourceDescriptor(new ResourceID("bar")))
 				.build();
 		final GroupRequest otheruser = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("other"), new UserName("baz"),
@@ -2886,8 +2890,8 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(inst(1130000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("2")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("2")))
 				.build());
 		
 		assertRequestListCorrect(
@@ -2924,7 +2928,7 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(120000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("bar")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("bar")))
 				.build();
 		final GroupRequest second = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo2"), new UserName("whee"),
@@ -2932,9 +2936,9 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(130000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-						new ResourceID("m.n")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m"),
+								new ResourceID("m.n")))
 				.build();
 		final GroupRequest third = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo3"), new UserName("whee"),
@@ -2942,7 +2946,7 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(140000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("bar")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("bar")))
 				.build();
 		final GroupRequest fourth = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo4"), new UserName("whee"),
@@ -2950,8 +2954,8 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(150000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("1")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("1")))
 				.build();
 		final GroupRequest fifth = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo5"), new UserName("whee"),
@@ -2959,7 +2963,7 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(160000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("bar")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("bar")))
 				.build();
 		final GroupRequest user = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("use"), new UserName("bar"),
@@ -2972,17 +2976,17 @@ public class MongoGroupsStorageOpsTest {
 					CreateModAndExpireTimes.getBuilder(
 							Instant.ofEpochMilli(20000), forever)
 					.build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("1")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("1")))
 				.build();
 		final GroupRequest requestcat = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("reqcat"), new UserName("bar"),
 					CreateModAndExpireTimes.getBuilder(
 							Instant.ofEpochMilli(20000), forever)
 					.build())
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-						new ResourceID("m.n")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m"),
+								new ResourceID("m.n")))
 				.build();
 		final GroupRequest othertarget = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("other"), new UserName("baz"),
@@ -2990,7 +2994,7 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 							.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("bat")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("bat")))
 				.build();
 		final GroupRequest otherws = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("otherws"), new UserName("baz"),
@@ -2999,8 +3003,8 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(125000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("2")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("2")))
 				.build();
 		final GroupRequest othercat = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("othercat"), new UserName("baz"),
@@ -3009,9 +3013,9 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(Instant.ofEpochMilli(135000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m2"),
-						new ResourceID("m2.n")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m2"),
+								new ResourceID("m2.n")))
 				.build();
 		final GroupRequest closed = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("closed"), new UserName("whee"),
@@ -3019,7 +3023,7 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(inst(170000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("bar")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("bar")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build();
 		final GroupRequest closedws = GroupRequest.getBuilder(
@@ -3028,8 +3032,8 @@ public class MongoGroupsStorageOpsTest {
 							.withModificationTime(inst(110000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("1")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("1")))
 				.withStatus(GroupRequestStatus.canceled())
 				.build();
 		
@@ -3216,7 +3220,8 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(inst(1030000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResource(ResourceDescriptor.from(new UserName("target1")))
+				.withResource(GroupRequest.USER_TYPE,
+						ResourceDescriptor.from(new UserName("target1")))
 				.build());
 		manager.storage.storeRequest(GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("gid1"), new UserName("name1"),
@@ -3224,8 +3229,8 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(inst(1130000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("5")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("5")))
 				.build());
 		manager.storage.storeRequest(GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("gid1"), new UserName("name1"),
@@ -3233,9 +3238,9 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(inst(1130000))
 						.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m5"),
-						new ResourceID("m5.m")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m5"),
+								new ResourceID("m5.m")))
 				.build());
 		
 		assertRequestListCorrect(
@@ -3317,25 +3322,25 @@ public class MongoGroupsStorageOpsTest {
 					CreateModAndExpireTimes.getBuilder(Instant.ofEpochMilli(40000), forever)
 							.withModificationTime(Instant.ofEpochMilli(130000))
 							.build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("45")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("45")))
 				.build();
 		final GroupRequest third = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo"), new UserName("bar3"),
 					CreateModAndExpireTimes.getBuilder(Instant.ofEpochMilli(30000), forever)
 							.withModificationTime(Instant.ofEpochMilli(140000))
 							.build())
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-						new ResourceID("m.m")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m"),
+								new ResourceID("m.m")))
 				.build();
 		final GroupRequest fourth = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo"), new UserName("bar4"),
 					CreateModAndExpireTimes.getBuilder(Instant.ofEpochMilli(20000), forever)
 							.withModificationTime(Instant.ofEpochMilli(150000))
 							.build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("42")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("42")))
 				.build();
 		// any request with a target user is excluded
 		final GroupRequest target = GroupRequest.getBuilder(
@@ -3344,8 +3349,8 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("foo")))
+				.withResource(new ResourceType("user"),
+						ResourceDescriptor.from(new UserName("foo")))
 				.build();
 		// same for invite workspace requests
 		final GroupRequest targetws = GroupRequest.getBuilder(
@@ -3354,8 +3359,8 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("86")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("86")))
 				.build();
 		// and invite method requests
 		final GroupRequest targetcat = GroupRequest.getBuilder(
@@ -3364,9 +3369,9 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-						new ResourceID("m.m")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m"),
+								new ResourceID("m.m")))
 				.build();
 		final GroupRequest othergroup = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("other"), new UserName("other"),
@@ -3485,8 +3490,8 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(inst(1130000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("2")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("2")))
 				.build());
 		
 		assertRequestListCorrect(
@@ -3558,8 +3563,7 @@ public class MongoGroupsStorageOpsTest {
 						.build())
 				.withStatus(GroupRequestStatus.from(st, new UserName("c"), "r"))
 				.withType(type)
-				.withResourceType(restype)
-				.withResource(resource)
+				.withResource(restype, resource)
 				.build();
 		return req;
 	}
@@ -3600,25 +3604,25 @@ public class MongoGroupsStorageOpsTest {
 					CreateModAndExpireTimes.getBuilder(Instant.ofEpochMilli(40000), forever)
 							.withModificationTime(Instant.ofEpochMilli(130000))
 							.build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("45")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("45")))
 				.build();
 		final GroupRequest third = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo2"), new UserName("bar3"),
 					CreateModAndExpireTimes.getBuilder(Instant.ofEpochMilli(30000), forever)
 							.withModificationTime(Instant.ofEpochMilli(140000))
 							.build())
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-						new ResourceID("m.m")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m"),
+								new ResourceID("m.m")))
 				.build();
 		final GroupRequest fourth = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("foo3"), new UserName("bar4"),
 					CreateModAndExpireTimes.getBuilder(Instant.ofEpochMilli(20000), forever)
 							.withModificationTime(Instant.ofEpochMilli(150000))
 							.build())
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("42")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("42")))
 				.build();
 		// any request with a target user is excluded
 		final GroupRequest target = GroupRequest.getBuilder(
@@ -3627,8 +3631,7 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("user"))
-				.withResource(ResourceDescriptor.from(new UserName("foo")))
+				.withResource(GroupRequest.USER_TYPE, ResourceDescriptor.from(new UserName("foo")))
 				.build();
 		// same for invite workspace requests
 		final GroupRequest targetws = GroupRequest.getBuilder(
@@ -3637,8 +3640,8 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("86")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("86")))
 				.build();
 		// and invite method requests
 		final GroupRequest targetcat = GroupRequest.getBuilder(
@@ -3647,9 +3650,9 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), forever)
 					.build())
 				.withType(RequestType.INVITE)
-				.withResourceType(new ResourceType("catalogmethod"))
-				.withResource(new ResourceDescriptor(new ResourceAdministrativeID("m"),
-						new ResourceID("m.m")))
+				.withResource(new ResourceType("catalogmethod"),
+						new ResourceDescriptor(new ResourceAdministrativeID("m"),
+								new ResourceID("m.m")))
 				.build();
 		final GroupRequest othergroup = GroupRequest.getBuilder(
 				new RequestID(UUID.randomUUID()), new GroupID("other"), new UserName("other"),
@@ -3775,8 +3778,8 @@ public class MongoGroupsStorageOpsTest {
 						.withModificationTime(inst(1130000))
 						.build())
 				.withType(RequestType.REQUEST)
-				.withResourceType(new ResourceType("workspace"))
-				.withResource(new ResourceDescriptor(new ResourceID("2")))
+				.withResource(new ResourceType("workspace"),
+						new ResourceDescriptor(new ResourceID("2")))
 				.build());
 		
 		assertRequestListCorrect(
@@ -3823,7 +3826,8 @@ public class MongoGroupsStorageOpsTest {
 							Instant.ofEpochMilli(20000), Instant.ofEpochMilli(30000))
 							.build())
 				.withType(RequestType.INVITE)
-				.withResource(new ResourceDescriptor(new ResourceID("baz")))
+				.withResource(GroupRequest.USER_TYPE,
+						new ResourceDescriptor(new ResourceID("baz")))
 				.build());
 		// closed
 		manager.storage.storeRequest(GroupRequest.getBuilder(


### PR DESCRIPTION
Asking for stupid bugs here. Also, all the code always sets both