### PR TITLE
SCT-1806 Add isPublic(resource) method to resource handlers

### DIFF
--- a/src/us/kbase/groups/cataloghandler/SDKClientCatalogHandler.java
+++ b/src/us/kbase/groups/cataloghandler/SDKClientCatalogHandler.java
@@ -104,6 +104,12 @@ public class SDKClientCatalogHandler implements ResourceHandler {
 		checkNotNull(user, "user");
 		return getModuleOwners(resource).contains(user.getName());
 	}
+	
+	@Override
+	public boolean isPublic(final ResourceID resource) throws IllegalResourceIDException {
+		getModMeth(resource); // check format
+		return true;
+	}
 
 	private List<String> getModuleOwners(final ResourceID module)
 			throws ResourceHandlerException, NoSuchResourceException, IllegalResourceIDException {
@@ -235,7 +241,7 @@ public class SDKClientCatalogHandler implements ResourceHandler {
 	}
 
 	@Override
-	public void setReadPermission(ResourceID resource, UserName user) {
+	public void setReadPermission(final ResourceID resource, final UserName user) {
 		return; // nothing to do, catalog methods are all public
 	}
 }

--- a/src/us/kbase/groups/core/resource/ResourceHandler.java
+++ b/src/us/kbase/groups/core/resource/ResourceHandler.java
@@ -36,6 +36,17 @@ public interface ResourceHandler {
 	boolean isAdministrator(ResourceID resource, UserName user)
 			throws IllegalResourceIDException, ResourceHandlerException, NoSuchResourceException;
 
+	/** Check if a resource is public. The resource handler implementation may or may not
+	 * check for the existence of the resource if all resources are public.
+	 * @param resource the resource to check.
+	 * @return true if the resource is public, false otherwise.
+	 * @throws IllegalResourceIDException if the resource ID is not in a legal format.
+	 * @throws ResourceHandlerException if an error occurs contacting the resource service.
+	 * @throws NoSuchResourceException if there is no such resource.
+	 */
+	boolean isPublic(ResourceID resource)
+			throws IllegalResourceIDException, ResourceHandlerException, NoSuchResourceException;
+	
 	/** Get the set of administrators of a resource.
 	 * @param resource the resource.
 	 * @return the set of administrators of that resource.

--- a/src/us/kbase/groups/storage/GroupsStorage.java
+++ b/src/us/kbase/groups/storage/GroupsStorage.java
@@ -115,8 +115,7 @@ public interface GroupsStorage {
 	
 	/** Get groups in the system, sorted by the group ID.
 	 * At most 100 groups are returned.
-	 * If the user is null and the user's role is not {@link Group.Role#NONE} no groups
-	 * are returned.
+	 * If the user is null and the user's role is not None no groups are returned.
 	 * If the user is null, a resource is present in the parameters, and that resource is private,
 	 * no groups are returned.
 	 * @param params the parameters for getting the groups.

--- a/src/us/kbase/test/groups/cataloghandler/SDKClientCatalogHandlerTest.java
+++ b/src/us/kbase/test/groups/cataloghandler/SDKClientCatalogHandlerTest.java
@@ -188,7 +188,7 @@ public class SDKClientCatalogHandlerTest {
 				.isAdministrator(new ResourceID("modname.mod"), new UserName(name)), is(expected));
 	}
 	
-	public ModuleVersionInfo getMVI(final List<String> narrs, final List<String> locals) {
+	private ModuleVersionInfo getMVI(final List<String> narrs, final List<String> locals) {
 		final ModuleVersionInfo mvi = new ModuleVersionInfo();
 		mvi.setAdditionalProperties("local_functions", locals);
 		mvi.setAdditionalProperties("narrative_methods", narrs);
@@ -273,6 +273,30 @@ public class SDKClientCatalogHandlerTest {
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
+	public void isPublic() throws Exception {
+		final SDKClientCatalogHandler cli = new SDKClientCatalogHandler(mock(CatalogClient.class));
+		
+		assertThat("incorrect is public", cli.isPublic(new ResourceID("foo.bar")), is(true));
+		assertThat("incorrect is public", cli.isPublic(new ResourceID("DataFileUtil.get_objects")),
+				is(true));
+	}
+	
+	@Test
+	public void isPublicFailBadID() throws Exception {
+		final SDKClientCatalogHandler cli = new SDKClientCatalogHandler(mock(CatalogClient.class));
+		
+		for (final String mm: BAD_NAMES.keySet()) {
+			try {
+				cli.isPublic(new ResourceID(mm));
+				fail("expected exception");
+			} catch (Exception got) {
+				TestCommon.assertExceptionCorrect(got, new IllegalResourceIDException(
+						"Illegal catalog method name: " + BAD_NAMES.get(mm)));
+			}
 		}
 	}
 	


### PR DESCRIPTION
Will be needed for listing groups by resource, since whether the
resource is public or not determines whether it's visible to users